### PR TITLE
Double keyword refactor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Memoization = "6fafb56a-5788-4b4e-91ca-c0cea6611c73"
 Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+SemistandardTableaux = "4fa827a6-5f60-431e-8381-c8437c5e3c04"
 
 [weakdeps]
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
@@ -22,6 +23,7 @@ Memoization = "0.2"
 Nemo = "0.52"
 Plots = "1"
 Printf = "1.10.0"
+SemistandardTableaux = "0.1"
 julia = "1.10.9"
 
 [extras]

--- a/src/SchubertPolynomials.jl
+++ b/src/SchubertPolynomials.jl
@@ -51,18 +51,30 @@ import Printf:
 # bpds
 using BumplessPipeDreams
 
+# Tableaux and Schur polynomials live in SemistandardTableaux now; import the
+# names we re-export selectively (a blanket `using` would clash on `xy_ring`,
+# `ZZ`, `QQ`, `schur_poly`, etc. — see the deprecation shims those packages keep).
+import SemistandardTableaux
+import SemistandardTableaux:
+	Tableau, ssyt, ssyt_iterator, schur_poly, rsk, rsk_insert,
+	edelman_greene, edelman_greene_insert
+
 ################################################################################
 # Export (more exports are in the source files)
 ################################################################################
 
 export
 	ZZ, QQ, PolyRing, ZZMPolyRing, ZZMPolyRingElem, QQMPolyRing, QQMPolyRingElem,
-	
+
 	base_ring, polynomial_ring, gen, gens, nvars, vars, coefficients, evaluate,
 
-	BPD, all_bpds, all_Kbpds, flat_bpds, Rothe, is_asm, bpd2asm, asm2bpd, bpd2word, 
-	
-	bpd2perm, isreduced, isflat
+	BPD, all_bpds, all_Kbpds, flat_bpds, Rothe, is_asm, bpd2asm, asm2bpd, bpd2word,
+
+	bpd2perm, isreduced, isflat,
+
+	# re-exported from SemistandardTableaux
+	Tableau, ssyt, ssyt_iterator, schur_poly, rsk, rsk_insert,
+	edelman_greene, edelman_greene_insert
 
 
 
@@ -74,7 +86,9 @@ include("subsets.jl")
 include("double_poly_ring.jl")
 include("permtools.jl")
 include("permutations.jl") # meant to replace `permtools.jl`, missing some functionality; must be included after `subsets.jl`
-include("ssyt.jl") # must be included after `double_poly_ring.jl`
+# Tableaux/Schur moved to SemistandardTableaux.jl (imported above); ssyt.jl is
+# kept on disk for one version but no longer included.
+#include("ssyt.jl") # must be included after `double_poly_ring.jl`
 include("pds.jl") # must be included after `permutations.jl`
 #include("bpds.jl")
 # Drift methods have moved to DriftPolynomials.jl.  The drift source files are

--- a/src/SchubertPolynomials.jl
+++ b/src/SchubertPolynomials.jl
@@ -23,7 +23,7 @@ import Combinatorics:
 
 # AbstractAlgebra
 import AbstractAlgebra:
-	base_ring, gen, gens, parent_type, nvars, polynomial_ring, MPolyBuildCtx, push_term!, finish
+	base_ring, gen, gens, parent_type, nvars, polynomial_ring, MPolyBuildCtx, push_term!, finish, MPolyRing
 
 # Nemo
 import Nemo:
@@ -57,7 +57,7 @@ using BumplessPipeDreams
 import SemistandardTableaux
 import SemistandardTableaux:
 	Tableau, ssyt, ssyt_iterator, schur_poly, rsk, rsk_insert,
-	edelman_greene, edelman_greene_insert
+	edelman_greene, edelman_greene_insert, extract_vars
 
 ################################################################################
 # Export (more exports are in the source files)
@@ -74,7 +74,7 @@ export
 
 	# re-exported from SemistandardTableaux
 	Tableau, ssyt, ssyt_iterator, schur_poly, rsk, rsk_insert,
-	edelman_greene, edelman_greene_insert
+	edelman_greene, edelman_greene_insert, extract_vars
 
 
 

--- a/src/SchubertPolynomials.jl
+++ b/src/SchubertPolynomials.jl
@@ -77,8 +77,11 @@ include("permutations.jl") # meant to replace `permtools.jl`, missing some funct
 include("ssyt.jl") # must be included after `double_poly_ring.jl`
 include("pds.jl") # must be included after `permutations.jl`
 #include("bpds.jl")
-include("drifts.jl")
-include("drift_polys.jl") # must be included after `drifts.jl`
+# Drift methods have moved to DriftPolynomials.jl.  The drift source files are
+# kept for one version but no longer included; `compat.jl` provides migration
+# shims for the names that used to live here.
+#include("drifts.jl")
+#include("drift_polys.jl") # must be included after `drifts.jl`
 #include("draw_bpds.jl") # must be included after `bpds.jl` & `drifts.jl`
 include("schub_polys.jl")
 include("schubert_sum.jl")
@@ -88,5 +91,7 @@ include("dominant_sum.jl")
 include("back_stable.jl")
 
 include("specialize.jl")
+
+include("compat.jl")
 
 end

--- a/src/back_stable.jl
+++ b/src/back_stable.jl
@@ -30,7 +30,7 @@ julia> back_schub_poly( [1,3,4,2], R )
 ```
 Here `ss[lambda]` stands for the dominant polynomial corresponding to a partition `lambda`.
 """
-function back_schub_poly(w, R::DoublePolyRing=xy_ring( max(length(w)-1,1))[1] )
+function back_schub_poly(w, R::DoublePolyRing=xy_ring( max(length(w)-1,1))[1]; double::Bool=false )
 
   w=trimw(w)
 
@@ -42,7 +42,7 @@ function back_schub_poly(w, R::DoublePolyRing=xy_ring( max(length(w)-1,1))[1] )
   for b in bpds
     la = dominant_part(b)
     if !(la in pars)
-      aa = acoeff(w,la,R)
+      aa = acoeff(w,la,R; double=double)
       push!(pars, la)
       push!(cfs, aa)
     end
@@ -54,7 +54,7 @@ end
 
 
 # get the coefficient of the (dominant) s[lambda] in the (back stable) Schubert polynomial S[w]
-function acoeff( w::Vector{Int}, lambda::Vector{Int}, R::DoublePolyRing=xy_ring(length(w)-1)[1] )
+function acoeff( w::Vector{Int}, lambda::Vector{Int}, R::DoublePolyRing=xy_ring(length(w)-1)[1]; double::Bool=false )
 
   lam = trimp(lambda)
 
@@ -63,18 +63,18 @@ function acoeff( w::Vector{Int}, lambda::Vector{Int}, R::DoublePolyRing=xy_ring(
 
   for b in all_bpds(w)
     if dominant_part(b)==lam
-      apol = apol + bpd2bin_star( b, R )
+      apol = apol + bpd2bin_star( b, R; double=double )
     end
-  end     
+  end
 
   return apol
 end
 
 
-function bpd2bin_star( bpd::BPD, R::DoublePolyRing=xy_ring( size(bpd.mtx)[1]-1, size(bpd.mtx)[2]-1 )[1] )
+function bpd2bin_star( bpd::BPD, R::DoublePolyRing=xy_ring( size(bpd.mtx)[1]-1, size(bpd.mtx)[2]-1 )[1]; double::Bool=false )
 # product of binomials for bpd
 # only schub version now
-# can get single polyn by using no y_vars
+# `double=false` (default) ignores any y-variables, giving the single polynomial
   local n=size(bpd.mtx)[1]-1
   bin = R.ring(1)
 
@@ -82,7 +82,7 @@ function bpd2bin_star( bpd::BPD, R::DoublePolyRing=xy_ring( size(bpd.mtx)[1]-1, 
   y = R.y_vars
 
   local aa=length(x)
-  local bb=length(y)
+  local bb= double ? length(y) : 0
 
   la = dominant_part(bpd)
   la = vcat( la, zeros(Int, n-length(la)) )

--- a/src/back_stable.jl
+++ b/src/back_stable.jl
@@ -8,29 +8,32 @@ export back_schub_poly, acoeff, schub2dom
 #############
 
 """
-    back_schub_poly(w, R)
+    back_schub_poly(w; double=false, ring=schub_ring(length(w)-1, length(w)-1))
 
 Return the back stable Schubert polynomial for the permutation `w`
 
 ## Arguments
 - `w::Vector{Int}`: A permutation
-- `R::DoublePolyRing`: The ambient polynomial ring, with underlying ring `R.ring` and variables `R.x_vars` and `R.y_vars`
 
+## Keywords
+- `double::Bool`: when `true`, coefficients are the double/equivariant polynomials in the y-variables of `ring`.  Default `false`.
+- `ring::MPolyRing`: The ambient polynomial ring (build with `schub_ring`).  Defaults to `schub_ring(length(w)-1, length(w)-1)`.
 
 ## Returns
-`DominantSum`: the back stable Schubert polynomial, written in the basis of dominant polynomials, with coefficients in R
+`DominantSum`: the back stable Schubert polynomial, written in the basis of dominant polynomials, with coefficients in `ring`
 
 ## Example
 
 ```julia-repl
-julia> R = xy_ring(4,4)[1];
+julia> R = schub_ring(4,4);
 
-julia> back_schub_poly( [1,3,4,2], R )
+julia> back_schub_poly( [1,3,4,2]; ring=R, double=true )
 (x2*x3 + x2*y2 + x3*y2 + y2^2)*ss[] + ss[1, 1] + (x3 + y2)*ss[1]
 ```
 Here `ss[lambda]` stands for the dominant polynomial corresponding to a partition `lambda`.
 """
-function back_schub_poly(w, R::DoublePolyRing=xy_ring( max(length(w)-1,1))[1]; double::Bool=false )
+function back_schub_poly(w; double::Bool=false,
+                         ring::MPolyRing=schub_ring( max(length(w)-1,1), max(length(w)-1,1) ) )
 
   w=trimw(w)
 
@@ -42,7 +45,7 @@ function back_schub_poly(w, R::DoublePolyRing=xy_ring( max(length(w)-1,1))[1]; d
   for b in bpds
     la = dominant_part(b)
     if !(la in pars)
-      aa = acoeff(w,la,R; double=double)
+      aa = acoeff(w,la; double=double, ring=ring)
       push!(pars, la)
       push!(cfs, aa)
     end
@@ -54,16 +57,17 @@ end
 
 
 # get the coefficient of the (dominant) s[lambda] in the (back stable) Schubert polynomial S[w]
-function acoeff( w::Vector{Int}, lambda::Vector{Int}, R::DoublePolyRing=xy_ring(length(w)-1)[1]; double::Bool=false )
+function acoeff( w::Vector{Int}, lambda::Vector{Int}; double::Bool=false,
+                 ring::MPolyRing=schub_ring(length(w)-1, length(w)-1) )
 
   lam = trimp(lambda)
 
-  apol = R.ring(0)
+  apol = ring(0)
 
 
   for b in all_bpds(w)
     if dominant_part(b)==lam
-      apol = apol + bpd2bin_star( b, R; double=double )
+      apol = apol + bpd2bin_star( b, ring; double=double )
     end
   end
 
@@ -71,15 +75,15 @@ function acoeff( w::Vector{Int}, lambda::Vector{Int}, R::DoublePolyRing=xy_ring(
 end
 
 
-function bpd2bin_star( bpd::BPD, R::DoublePolyRing=xy_ring( size(bpd.mtx)[1]-1, size(bpd.mtx)[2]-1 )[1]; double::Bool=false )
+function bpd2bin_star( bpd::BPD, R::MPolyRing=schub_ring( size(bpd.mtx)[1]-1, size(bpd.mtx)[2]-1 ); double::Bool=false )
 # product of binomials for bpd
 # only schub version now
 # `double=false` (default) ignores any y-variables, giving the single polynomial
   local n=size(bpd.mtx)[1]-1
-  bin = R.ring(1)
+  bin = R(1)
 
-  x = R.x_vars
-  y = R.y_vars
+  x = extract_vars(R; varname=:x)
+  y = extract_vars(R; varname=:y)
 
   local aa=length(x)
   local bb= double ? length(y) : 0
@@ -91,7 +95,7 @@ function bpd2bin_star( bpd::BPD, R::DoublePolyRing=xy_ring( size(bpd.mtx)[1]-1, 
     for j=la[i]+2:n
 
       if bpd.mtx[i,j]==0
-        p=R.ring(0)
+        p=R(0)
         if i<=aa
           p=p+x[i]
         end
@@ -111,14 +115,17 @@ function bpd2bin_star( bpd::BPD, R::DoublePolyRing=xy_ring( size(bpd.mtx)[1]-1, 
 end
 
 """
-    schub2dom(SS, R)
+    schub2dom(SS; ring=schub_ring(maxlen-1, maxlen-1), double=false)
 
 Convert a `SchubertSum` to a `DominantSum` by expanding each Schubert polynomial S[w]
 as a back stable Schubert polynomial in the dominant basis.
 
 ## Arguments
 - `SS::SchubertSum`: A sum of Schubert polynomials
-- `R::DoublePolyRing`: The ambient polynomial ring (optional, will be inferred from the largest permutation if not provided)
+
+## Keywords
+- `ring::MPolyRing`: The ambient polynomial ring (build with `schub_ring`).  Defaults to a ring sized by the largest permutation in `SS`.
+- `double::Bool`: when `true`, coefficients are equivariant (in the y-variables of `ring`).  Default `false`.
 
 ## Returns
 `DominantSum`: the sum expressed in the basis of dominant polynomials
@@ -126,38 +133,27 @@ as a back stable Schubert polynomial in the dominant basis.
 ## Example
 
 ```julia-repl
-julia> R = xy_ring(4,4)[1];
-
 julia> SS = SchubertSum([1, 1], [[2,1,3], [1,3,2]]);
 
-julia> schub2dom(SS, R)
+julia> schub2dom(SS; ring=schub_ring(4,4), double=true)
 ```
 """
-function schub2dom(SS::SchubertSum, R::DoublePolyRing)
+function schub2dom(SS::SchubertSum;
+                   ring::MPolyRing=schub_ring( max(maximum(length.(SS.schubs))-1, 1),
+                                               max(maximum(length.(SS.schubs))-1, 1) ),
+                   double::Bool=false)
 
     # Start with the zero DominantSum in the polynomial ring
-    result = DominantSum([R.ring(0)], [[0]])
+    result = DominantSum([ring(0)], [[0]])
 
     # For each term c*S[w] in the SchubertSum
     for (c, w) in zip(SS.coeffs, SS.schubs)
         # Convert S[w] to dominant basis
-        dom_poly = back_schub_poly(w, R)
+        dom_poly = back_schub_poly(w; ring=ring, double=double)
 
         # Multiply by the coefficient and add to result
         result = result + c * dom_poly
     end
 
     return condense(result)
-end
-
-# Version without explicit R argument - infer the ring size
-function schub2dom(SS::SchubertSum)
-
-    # Find the maximum length among all permutations in SS
-    max_len = maximum(length.(SS.schubs))
-
-    # Create appropriate ring
-    R = xy_ring(max(max_len - 1, 1))[1]
-
-    return schub2dom(SS, R)
 end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -9,23 +9,93 @@
 """
     schur_poly(la, ff, R::DoublePolyRing; double=length(R.y_vars)>0, kwargs...)
 
-Legacy positional-ring adapter onto the keyword `schur_poly` in
-SemistandardTableaux.jl.  Prefer `schur_poly(la, ff; ring=, double=)`.
+Legacy positional-`DoublePolyRing` adapter onto the keyword `schur_poly` in
+SemistandardTableaux.jl.  Prefer `schur_poly(la, ff; ring=schub_ring(...), double=)`.
 
 The default `double=length(R.y_vars)>0` preserves the old behavior of this
-positional form (a ring with y-variables yields the double/factorial Schur
-polynomial).  When `double=false` the single Schur polynomial is returned in
-`R.ring`, using only its x-variables even if `R` carries y-variables.
+positional form (a ring with y-variables yielded the double/factorial Schur
+polynomial).  Single vs double is otherwise controlled by `double`.
 """
 function schur_poly(la, ff, R::DoublePolyRing; double::Bool=length(R.y_vars)>0, kwargs...)
-    if double || isempty(R.y_vars)
-        return SemistandardTableaux.schur_poly(la, ff; ring=R.ring, double=double, kwargs...)
-    end
-    # single polynomial in a ring that also has y-variables: build it in the
-    # x-only subring, then embed into R.ring by mapping x-generators across
-    xr, _ = polynomial_ring(base_ring(R.ring), ["x$i" for i in 1:length(R.x_vars)])
-    p = SemistandardTableaux.schur_poly(la, ff; ring=xr, kwargs...)
-    return evaluate(p, R.x_vars)   # map xr's generators onto R.x_vars, landing in R.ring
+    Base.depwarn(_RING_POSITIONAL, :schur_poly)
+    SemistandardTableaux.schur_poly(la, ff; ring=R.ring, double=double, kwargs...)
+end
+
+
+################################################################################
+# Deprecated positional / DoublePolyRing call forms.
+#
+# The ring is now a keyword argument and is a bare MPolyRing.  These shims accept
+# the old positional `DoublePolyRing` and forward to the keyword API.
+################################################################################
+
+const _RING_POSITIONAL =
+    "passing the ring positionally as a `DoublePolyRing` is deprecated; build the " *
+    "ring with `schub_ring` and pass it as the `ring` keyword"
+
+function schub_poly(w::Vector{Int}, R::DoublePolyRing; kwargs...)
+    Base.depwarn(_RING_POSITIONAL, :schub_poly)
+    schub_poly(w; ring=R.ring, kwargs...)
+end
+
+function groth_poly(w::Vector{Int}, R::DoublePolyRing; kwargs...)
+    Base.depwarn(_RING_POSITIONAL, :groth_poly)
+    groth_poly(w; ring=R.ring, kwargs...)
+end
+
+function back_schub_poly(w, R::DoublePolyRing; kwargs...)
+    Base.depwarn(_RING_POSITIONAL, :back_schub_poly)
+    back_schub_poly(w; ring=R.ring, kwargs...)
+end
+
+function acoeff(w::Vector{Int}, lambda::Vector{Int}, R::DoublePolyRing; kwargs...)
+    Base.depwarn(_RING_POSITIONAL, :acoeff)
+    acoeff(w, lambda; ring=R.ring, kwargs...)
+end
+
+function mult_2schub(uu::Vector{Int}, vv::Vector{Int}, rnk::Int, R::DoublePolyRing; kwargs...)
+    Base.depwarn(_RING_POSITIONAL, :mult_2schub)
+    mult_2schub(uu, vv, rnk; ring=R.ring, kwargs...)
+end
+
+function lrc(uu::Vector{Int}, vv::Vector{Int}, ww::Vector{Int}, rnk::Int, R::DoublePolyRing; kwargs...)
+    Base.depwarn(_RING_POSITIONAL, :lrc)
+    lrc(uu, vv, ww, rnk; ring=R.ring, kwargs...)
+end
+
+function mult_schub(f::Union{Int,ZZMPolyRingElem}, ss::SchubertSum, rnk::Int, R::DoublePolyRing; kwargs...)
+    Base.depwarn(_RING_POSITIONAL, :mult_schub)
+    mult_schub(f, ss, rnk; ring=R.ring, kwargs...)
+end
+
+function mult_schub(f::Union{Int,ZZMPolyRingElem}, w::Vector{Int}, rnk::Int, R::DoublePolyRing; kwargs...)
+    Base.depwarn(_RING_POSITIONAL, :mult_schub)
+    mult_schub(f, w, rnk; ring=R.ring, kwargs...)
+end
+
+function expand_schub(f::Union{Int,ZZMPolyRingElem}, rnk::Int, R::DoublePolyRing; kwargs...)
+    Base.depwarn(_RING_POSITIONAL, :expand_schub)
+    expand_schub(f, rnk; ring=R.ring, kwargs...)
+end
+
+function localization(u::Vector{Int}, v::Vector{Int}, R::DoublePolyRing; kwargs...)
+    Base.depwarn(_RING_POSITIONAL, :localization)
+    localization(u, v; ring=R.ring, kwargs...)
+end
+
+function principal_specialization(pol::ZZMPolyRingElem, R::DoublePolyRing; kwargs...)
+    Base.depwarn(_RING_POSITIONAL, :principal_specialization)
+    principal_specialization(pol; ring=R.ring, kwargs...)
+end
+
+function principal_specialization(w::Vector{Int}, R::DoublePolyRing; kwargs...)
+    Base.depwarn(_RING_POSITIONAL, :principal_specialization)
+    principal_specialization(w; ring=R.ring, kwargs...)
+end
+
+function schub2dom(SS::SchubertSum, R::DoublePolyRing; kwargs...)
+    Base.depwarn(_RING_POSITIONAL, :schub2dom)
+    schub2dom(SS; ring=R.ring, kwargs...)
 end
 
 

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,0 +1,20 @@
+# Compatibility / deprecation shims.
+#
+# Drift methods have moved to DriftPolynomials.jl.  SchubertPolynomials no longer
+# depends on drifts in either direction.  The names below used to be exported
+# here; they are now unexported migration stubs that point users to the new home.
+# They are intentionally *not* exported, so that `using SchubertPolynomials,
+# DriftPolynomials` does not produce export-collision warnings.
+
+const _DRIFT_MOVED =
+    "drift methods have moved to DriftPolynomials.jl; add it to your project and " *
+    "`using DriftPolynomials`"
+
+for f in (:Drift, :drift_class, :drift_poly, :markconfig, :dc2sd,
+          :partition2drift, :bpd2drift, :nw_reset, :se_reset, :random_drift,
+          :isintegrable, :iscancelable, :drift2rkmtx, :rkmtx2asm, :empty_drift)
+    @eval function $f(args...; kwargs...)
+        error("`", $(string(f)), "` has been removed from SchubertPolynomials.jl; ",
+              _DRIFT_MOVED)
+    end
+end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -6,6 +6,29 @@
 # They are intentionally *not* exported, so that `using SchubertPolynomials,
 # DriftPolynomials` does not produce export-collision warnings.
 
+"""
+    schur_poly(la, ff, R::DoublePolyRing; double=length(R.y_vars)>0, kwargs...)
+
+Legacy positional-ring adapter onto the keyword `schur_poly` in
+SemistandardTableaux.jl.  Prefer `schur_poly(la, ff; ring=, double=)`.
+
+The default `double=length(R.y_vars)>0` preserves the old behavior of this
+positional form (a ring with y-variables yields the double/factorial Schur
+polynomial).  When `double=false` the single Schur polynomial is returned in
+`R.ring`, using only its x-variables even if `R` carries y-variables.
+"""
+function schur_poly(la, ff, R::DoublePolyRing; double::Bool=length(R.y_vars)>0, kwargs...)
+    if double || isempty(R.y_vars)
+        return SemistandardTableaux.schur_poly(la, ff; ring=R.ring, double=double, kwargs...)
+    end
+    # single polynomial in a ring that also has y-variables: build it in the
+    # x-only subring, then embed into R.ring by mapping x-generators across
+    xr, _ = polynomial_ring(base_ring(R.ring), ["x$i" for i in 1:length(R.x_vars)])
+    p = SemistandardTableaux.schur_poly(la, ff; ring=xr, kwargs...)
+    return evaluate(p, R.x_vars)   # map xr's generators onto R.x_vars, landing in R.ring
+end
+
+
 const _DRIFT_MOVED =
     "drift methods have moved to DriftPolynomials.jl; add it to your project and " *
     "`using DriftPolynomials`"

--- a/src/double_poly_ring.jl
+++ b/src/double_poly_ring.jl
@@ -1,126 +1,90 @@
-# DoublePolyRing
-# David Anderson, June 2024
+# Polynomial ring helpers for SchubertPolynomials.jl
+#
+# The package now works with a bare `MPolyRing` (mirroring `ssyt_ring` in
+# SemistandardTableaux): variables are named x1..xn then y1..ym, and the x- and
+# y-families are recovered by name with `extract_vars` (re-exported from
+# SemistandardTableaux).  The old `DoublePolyRing` type and `xy_ring` constructor
+# are kept for one version as deprecated shims.
 
 
-export DoublePolyRing, xy_ring
+export schub_ring
 
 
 #################
-# Polynomial constructors
+# Polynomial ring constructor
+#################
 
-######
+"""
+    schub_ring(n, m=0; coeff=ZZ, xname=:x, yname=:y) -> MPolyRing
+
+Polynomial ring with variables `x1..xn` then `y1..ym` over the coefficient ring
+`coeff` (default Nemo `ZZ`).  Mirrors `ssyt_ring` from SemistandardTableaux.
+
+Returns the ring itself (an `MPolyRing`), not a tuple of variable families; use
+`extract_vars(R; varname=:x)` / `extract_vars(R; varname=:y)` to recover them.
+
+A single (ordinary) polynomial lives in any such ring — pass `double=false` to a
+constructor and only the x-variables are used.  For a double/factorial
+polynomial, build a ring with y-variables (`m > 0`) and pass `double=true`.
+
+# Examples
+```julia-repl
+julia> R = schub_ring(3, 2)
+Multivariate polynomial ring in 5 variables x1, x2, x3, y1, y2 over integers
+
+julia> extract_vars(R; varname=:x)
+3-element Vector{ZZMPolyRingElem}:
+ x1
+ x2
+ x3
+
+# Over the rationals
+julia> R = schub_ring(3; coeff=QQ);
+```
+"""
+function schub_ring(n::Int, m::Int=0; coeff=ZZ, xname::Symbol=:x, yname::Symbol=:y)
+    names = vcat(["$(xname)$(i)" for i in 1:n], ["$(yname)$(j)" for j in 1:m])
+    R, _ = polynomial_ring(coeff, names)
+    return R
+end
+
+
+################################################################################
+# Deprecated: DoublePolyRing + xy_ring
+#
+# Retained for one version so existing scripts keep working.  Migrate
+#   R = xy_ring(n, m)[1]      ->  R = schub_ring(n, m)
+#   R.x_vars                  ->  extract_vars(R; varname=:x)
+#   R.y_vars                  ->  extract_vars(R; varname=:y)
+# and pass the ring as the `ring` keyword instead of positionally.
+################################################################################
+
+export DoublePolyRing, xy_ring
+
 struct DoublePolyRing
            ring::ZZMPolyRing
            x_vars::Vector{ZZMPolyRingElem}
            y_vars::Vector{ZZMPolyRingElem}
        end
 
-#####
 
-
-
-"""
-    xy_ring(xx,yy)
-
-Form a DoublePolyRing object
-
-## Arguments
-- `xx::Vector{String}`: the names of x variables
-- `yy::Vector{String}`: the names of y variables
-
-If xx, yy are given as Int, the names x1, x2, y1, y2, etc., are chosen.
-
-## Returns
-- `DoublePolyRing`, `Vector{ZZMPolyRingElem}`, `Vector{ZZMPolyRingElem}`: The double polynomial ring, with specified variable sets.
-
-# Examples
-```julia-repl
-# Define a DoublePolyRing with x-variables [a,b,c] and y-variables [\u03B1,\u03B2,\u03B3]
-julia> xx = ["a","b","c"]; yy = ["\u03B1","\u03B2","\u03B3"];
-
-julia> R,x,y = xy_ring(xx,yy)
-(DoublePolyRing(Multivariate polynomial ring in 6 variables over ZZ, ZZMPolyRingElem[a, b, c], ZZMPolyRingElem[\u03B1,\u03B2,\u03B3]), ZZMPolyRingElem[a, b, c], ZZMPolyRingElem[\u03B1,\u03B2,\u03B3])
-
-# Define a DoublePolyRing with three x-variables and two y-variables
-julia> R = xy_ring(3,2)[1]
-DoublePolyRing(Multivariate polynomial ring in 5 variables over ZZ, ZZMPolyRingElem[x1, x2, x3], ZZMPolyRingElem[y1, y2])
-
-# Extract the x variables
-julia> x = R.x_vars
-3-element Vector{ZZMPolyRingElem}:
- x1
- x2
- x3
-
-# Extract the y variables
-julia> y = R.y_vars
-2-element Vector{ZZMPolyRingElem}:
- y1
- y2
-
-# If only one argument is supplied, the result has empty y-variable set
-julia> R,x,y = xy_ring(3)
-(DoublePolyRing(Multivariate polynomial ring in 3 variables over ZZ, ZZMPolyRingElem[x1, x2, x3], ZZMPolyRingElem[]), ZZMPolyRingElem[x1, x2, x3], ZZMPolyRingElem[])
-
-```
-
-# Notes
-
-The ring is constructed from a `ZZMPolyRing` object in Nemo, so elements are of type `ZZMPolyRingElem`.
-
-"""
-function xy_ring(xx::Vector{String},yy::Vector{String})
-
+function xy_ring(xx::Vector{String}, yy::Vector{String})
+    Base.depwarn("`xy_ring`/`DoublePolyRing` are deprecated; use `schub_ring` " *
+                 "(returns an MPolyRing) with `extract_vars`.", :xy_ring)
     n=length(xx)
     m=length(yy)
-
-    R,all_vars = polynomial_ring(ZZ,vcat(xx,yy))
-
+    R, all_vars = polynomial_ring(ZZ, vcat(xx,yy))
     x = all_vars[1:n]
     y = all_vars[n+1:n+m]
-
     return DoublePolyRing(R,x,y), x, y
-
 end
 
+xy_ring(xx::Vector{String}) = xy_ring(xx, String[])
 
-function xy_ring(xx::Vector{String})
-    return xy_ring(xx,String[])
+function xy_ring(n::Int, m::Int)
+    xvars = ["x$(i)" for i=1:n]
+    yvars = ["y$(i)" for i=1:m]
+    xy_ring(xvars, yvars)
 end
 
-
-function xy_ring(n::Int,m::Int)
-
-  local xvars = ["x$(i)" for i=1:n]
-  local yvars = ["y$(i)" for i=1:m]
-
-  R,all_vars = polynomial_ring(ZZ,vcat(xvars,yvars))
-
-  x = all_vars[1:n]
-  y = all_vars[n+1:n+m]
-
-  return DoublePolyRing(R,x,y), x, y
-
-end
-
-
-function xy_ring(n::Int)
-  return xy_ring(n,0)
-end
-
-
-"""
-    default_ring(n_x, double)
-
-Return the default `DoublePolyRing` for a polynomial constructor.
-
-When `double=false` a y-free ring in `n_x` x-variables is built (a *single*
-polynomial lives there); when `double=true` a ring with `n_x` x-variables and
-`n_x` y-variables is built, as needed for a double/factorial polynomial. The
-single helper used by every defaulted signature, so that the "single in any
-ring" default is encoded in one place.
-"""
-default_ring(n_x::Int, double::Bool) =
-    double ? xy_ring(n_x, n_x)[1] : xy_ring(n_x, 0)[1]
-
-
+xy_ring(n::Int) = xy_ring(n, 0)

--- a/src/double_poly_ring.jl
+++ b/src/double_poly_ring.jl
@@ -109,3 +109,18 @@ function xy_ring(n::Int)
 end
 
 
+"""
+    default_ring(n_x, double)
+
+Return the default `DoublePolyRing` for a polynomial constructor.
+
+When `double=false` a y-free ring in `n_x` x-variables is built (a *single*
+polynomial lives there); when `double=true` a ring with `n_x` x-variables and
+`n_x` y-variables is built, as needed for a double/factorial polynomial. The
+single helper used by every defaulted signature, so that the "single in any
+ring" default is encoded in one place.
+"""
+default_ring(n_x::Int, double::Bool) =
+    double ? xy_ring(n_x, n_x)[1] : xy_ring(n_x, 0)[1]
+
+

--- a/src/drift_polys.jl
+++ b/src/drift_polys.jl
@@ -300,7 +300,7 @@ end
 
 
 
-function schub_drifts( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1] )
+function schub_drifts( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]; double::Bool=false )
 # compute schubert pol by drift class formula
 
   fbpds = flat_bpds(w)
@@ -309,7 +309,7 @@ function schub_drifts( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-
 
   for b in fbpds
     b=markconfig(b)
-    pol = pol+dc2sd(b,R)
+    pol = pol+dc2sd(b,R; double=double)
   end
 
   return pol
@@ -317,7 +317,7 @@ function schub_drifts( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-
 end
 
 
-function dc2sd( dc::Drift, R::DoublePolyRing=xy_ring( size(dc)[1], size(dc)[2] )[1]  )
+function dc2sd( dc::Drift, R::DoublePolyRing=xy_ring( size(dc)[1], size(dc)[2] )[1]; double::Bool=false  )
 # drift configuration to s-polynomial
 # must take marked configuration as input
 
@@ -327,7 +327,7 @@ function dc2sd( dc::Drift, R::DoublePolyRing=xy_ring( size(dc)[1], size(dc)[2] )
     for i=maximum([1,k-m]):minimum([n,k-1])
       if isa( dc.m[i,k-i], Tuple ) && dc.m[i,k-i][2]
         (dc1,dc2)=drift_split( dc, i, k-i )
-        return ( dc2sd( dc1, R ) + dc2sd( dc2, R ) )
+        return ( dc2sd( dc1, R; double=double ) + dc2sd( dc2, R; double=double ) )
       end
     end
   end
@@ -337,7 +337,7 @@ function dc2sd( dc::Drift, R::DoublePolyRing=xy_ring( size(dc)[1], size(dc)[2] )
   tcomps = tableau_components(dc)
 
   for tt in tcomps
-    sd = sd*schur_poly( tt[1], tt[2], R; mu=tt[3], xoffset=tt[4][1], yoffset=tt[4][2], rowmin=true )
+    sd = sd*schur_poly( tt[1], tt[2], R; double=double, mu=tt[3], xoffset=tt[4][1], yoffset=tt[4][2], rowmin=true )
   end
 
   return sd

--- a/src/mult_schub.jl
+++ b/src/mult_schub.jl
@@ -9,15 +9,18 @@ export mult_2schub, lrc, mult_schub, expand_schub, maxvar
 #########
 
 """
-    mult_2schub( uu, vv, rnk, R )
+    mult_2schub( uu, vv, rnk; double=false, ring=schub_ring(rnk-1, rnk-1) )
 
 Multiply two Schubert classes
 
 ## Arguments
 - `uu::Vector{Int}`: a permutation
-- `uu::Vector{Int}`: a permutation
+- `vv::Vector{Int}`: a permutation
 - `rnk::Int`: an integer specifying the ambient flag variety, Fl(rnk).  Defaults to the larger of the lengths of uu and vv.
-- `R::DoublePolyRing`: the ambient polynomial ring, with underlying ring `R.ring` and variables `R.x_vars` and `R.y_vars`.  Defaults to a single-variable ring in rnk-1 x variables.
+
+## Keywords
+- `double::Bool`: when `true`, computes the equivariant (double) product, using the y-variables of `ring`.  Default `false`.
+- `ring::MPolyRing`: the ambient polynomial ring (build with `schub_ring`).  Defaults to `schub_ring(rnk-1, rnk-1)`.
 
 ## Returns
 `SchubertSum`: a sum of Schubert classes
@@ -32,29 +35,31 @@ julia> v = [1,3,2];
 julia> mult_2schub( u, v, 3 )
 S[3, 1, 2] + S[2, 3, 1]
 
-# Define a double-variable DoublePolyRing
-julia> R = xy_ring(3,3)[1];
+# Equivariant product in a ring with y-variables
+julia> R = schub_ring(3,3);
 
-julia> mult_2schub( [2,3,1], [3,1,2], 4, R )
+julia> mult_2schub( [2,3,1], [3,1,2], 4; ring=R, double=true )
 (y1 - y3)*S[3, 2, 1] + S[4, 2, 1, 3]
 ```
 """
-function mult_2schub( uu::Vector{Int}, vv::Vector{Int}, rnk::Int=maximum([length(uu),length(vv)]), R::DoublePolyRing=xy_ring(rnk-1)[1]; double::Bool=false )
+function mult_2schub( uu::Vector{Int}, vv::Vector{Int}, rnk::Int=maximum([length(uu),length(vv)]);
+                      double::Bool=false, ring::MPolyRing=schub_ring(rnk-1, rnk-1) )
 
-  len(uu)>len(vv) && return mult_2schub( vv, uu, rnk, R; double=double )
+  len(uu)>len(vv) && return mult_2schub( vv, uu, rnk; double=double, ring=ring )
 
-  f = schub_poly(uu,R; double=double)
+  f = schub_poly(uu; ring=ring, double=double)
 
-  return mult_schub( f, vv, rnk, R; double=double )
+  return mult_schub( f, vv, rnk; double=double, ring=ring )
 
 end
 
 
 
 # get the schubert structure constant, default non-equivariant
-function lrc( uu::Vector{Int}, vv::Vector{Int}, ww::Vector{Int}, rnk::Int=maximum([length(uu),length(vv),length(ww)]), R::DoublePolyRing=xy_ring(rnk-1)[1]; double::Bool=false )
+function lrc( uu::Vector{Int}, vv::Vector{Int}, ww::Vector{Int}, rnk::Int=maximum([length(uu),length(vv),length(ww)]);
+              double::Bool=false, ring::MPolyRing=schub_ring(rnk-1, rnk-1) )
 
-  ss = mult_2schub( uu, vv, rnk, R; double=double )
+  ss = mult_2schub( uu, vv, rnk; double=double, ring=ring )
 
   return coeff( ss, ww )
 
@@ -63,7 +68,8 @@ end
 
 
 # multiply a polynomial by a schubert sum, default non-equivariant
-function mult_schub(f::Union{Int,ZZMPolyRingElem}, ss::SchubertSum, rnk::Int=maximum( length.(ss.schubs) ), R::Union{ZZMPolyRing,DoublePolyRing}=xy_ring(rnk-1)[1]; double::Bool=false )
+function mult_schub(f::Union{Int,ZZMPolyRingElem}, ss::SchubertSum, rnk::Int=maximum( length.(ss.schubs) );
+                    double::Bool=false, ring::MPolyRing=schub_ring(rnk-1, rnk-1) )
 
   i = maxvar(f)
   cfs = copy(ss.coeffs)
@@ -73,12 +79,7 @@ function mult_schub(f::Union{Int,ZZMPolyRingElem}, ss::SchubertSum, rnk::Int=max
     return SchubertSum( cfs, ss.schubs )
   end
 
-  if isa( R, DoublePolyRing )
-    xx = R.x_vars
-  else
-    xx = gens(R)
-  end
-
+  xx = extract_vars(ring; varname=:x)
 
   ii = findfirst( isequal("x$(i)"), string.(xx) )
 
@@ -86,28 +87,30 @@ function mult_schub(f::Union{Int,ZZMPolyRingElem}, ss::SchubertSum, rnk::Int=max
 
   f2 = divrem( f-f1, xx[ii] )[1]
 
-  ss1 = mult_schub( f1, ss, rnk, R; double=double )  # maxvar less than i
+  ss1 = mult_schub( f1, ss, rnk; double=double, ring=ring )  # maxvar less than i
 
-  ss2 = mult_schub( f2, ss, rnk, R; double=double )  # lower degree in xi
+  ss2 = mult_schub( f2, ss, rnk; double=double, ring=ring )  # lower degree in xi
 
-  ssmk = monk(ss2,i,rnk,R; double=double) # put the xi back in
+  ssmk = monk(ss2,i,rnk,ring; double=double) # put the xi back in
 
   return condense( ss1+ssmk )
 
 end
 
 # to multiply by a single w, default non-equivariant
-function mult_schub(f::Union{Int,ZZMPolyRingElem}, w::Vector{Int}, rnk::Int=length(w), R::Union{ZZMPolyRing,DoublePolyRing}=xy_ring(rnk-1)[1]; double::Bool=false )
+function mult_schub(f::Union{Int,ZZMPolyRingElem}, w::Vector{Int}, rnk::Int=length(w);
+                    double::Bool=false, ring::MPolyRing=schub_ring(rnk-1, rnk-1) )
   ss = SchubertSum(w)
-  return mult_schub(f,ss,rnk,R; double=double)
+  return mult_schub(f,ss,rnk; double=double, ring=ring)
 end
 
 
 
 # expand a polynomial in Schubert basis, default non-equivariant
-function expand_schub( f::Union{Int,ZZMPolyRingElem}, rnk::Int=maxvar( f ), R::Union{ZZMPolyRing,DoublePolyRing}=parent(f); double::Bool=false )
+function expand_schub( f::Union{Int,ZZMPolyRingElem}, rnk::Int=maxvar( f );
+                       double::Bool=false, ring::MPolyRing=parent(f) )
 
-  return mult_schub( f, [1], rnk, R; double=double )
+  return mult_schub( f, [1], rnk; double=double, ring=ring )
 
 end
 
@@ -138,7 +141,7 @@ function maxvar(f::Int)
 end
 
 
-function monk(ss::SchubertSum, i::Int, rnk::Int, R::Union{DoublePolyRing,ZZMPolyRing}=xy_ring(rnk)[1]; double::Bool=false)
+function monk(ss::SchubertSum, i::Int, rnk::Int, R::MPolyRing=schub_ring(rnk, rnk); double::Bool=false)
 
   if i>rnk || i<0
     return(ss)
@@ -146,10 +149,10 @@ function monk(ss::SchubertSum, i::Int, rnk::Int, R::Union{DoublePolyRing,ZZMPoly
 
   ll = length(ss)
 
-  if double && isa(R, DoublePolyRing)
-    yy = R.y_vars
+  if double
+    yy = extract_vars(R; varname=:y)
   else
-    yy = Int[]
+    yy = ZZMPolyRingElem[]
   end
 
 

--- a/src/mult_schub.jl
+++ b/src/mult_schub.jl
@@ -39,22 +39,22 @@ julia> mult_2schub( [2,3,1], [3,1,2], 4, R )
 (y1 - y3)*S[3, 2, 1] + S[4, 2, 1, 3]
 ```
 """
-function mult_2schub( uu::Vector{Int}, vv::Vector{Int}, rnk::Int=maximum([length(uu),length(vv)]), R::DoublePolyRing=xy_ring(rnk-1)[1] )
+function mult_2schub( uu::Vector{Int}, vv::Vector{Int}, rnk::Int=maximum([length(uu),length(vv)]), R::DoublePolyRing=xy_ring(rnk-1)[1]; double::Bool=false )
 
-  len(uu)>len(vv) && return mult_2schub( vv, uu, rnk, R )
+  len(uu)>len(vv) && return mult_2schub( vv, uu, rnk, R; double=double )
 
-  f = schub_poly(uu,R)
+  f = schub_poly(uu,R; double=double)
 
-  return mult_schub( f, vv, rnk, R )
+  return mult_schub( f, vv, rnk, R; double=double )
 
 end
 
 
 
 # get the schubert structure constant, default non-equivariant
-function lrc( uu::Vector{Int}, vv::Vector{Int}, ww::Vector{Int}, rnk::Int=maximum([length(uu),length(vv),length(ww)]), R::DoublePolyRing=xy_ring(rnk-1)[1] )
+function lrc( uu::Vector{Int}, vv::Vector{Int}, ww::Vector{Int}, rnk::Int=maximum([length(uu),length(vv),length(ww)]), R::DoublePolyRing=xy_ring(rnk-1)[1]; double::Bool=false )
 
-  ss = mult_2schub( uu, vv, rnk, R )
+  ss = mult_2schub( uu, vv, rnk, R; double=double )
 
   return coeff( ss, ww )
 
@@ -63,7 +63,7 @@ end
 
 
 # multiply a polynomial by a schubert sum, default non-equivariant
-function mult_schub(f::Union{Int,ZZMPolyRingElem}, ss::SchubertSum, rnk::Int=maximum( length.(ss.schubs) ), R::Union{ZZMPolyRing,DoublePolyRing}=xy_ring(rnk-1)[1] )
+function mult_schub(f::Union{Int,ZZMPolyRingElem}, ss::SchubertSum, rnk::Int=maximum( length.(ss.schubs) ), R::Union{ZZMPolyRing,DoublePolyRing}=xy_ring(rnk-1)[1]; double::Bool=false )
 
   i = maxvar(f)
   cfs = copy(ss.coeffs)
@@ -86,28 +86,28 @@ function mult_schub(f::Union{Int,ZZMPolyRingElem}, ss::SchubertSum, rnk::Int=max
 
   f2 = divrem( f-f1, xx[ii] )[1]
 
-  ss1 = mult_schub( f1, ss, rnk, R )  # maxvar less than i
+  ss1 = mult_schub( f1, ss, rnk, R; double=double )  # maxvar less than i
 
-  ss2 = mult_schub( f2, ss, rnk, R )  # lower degree in xi
+  ss2 = mult_schub( f2, ss, rnk, R; double=double )  # lower degree in xi
 
-  ssmk = monk(ss2,i,rnk,R) # put the xi back in
+  ssmk = monk(ss2,i,rnk,R; double=double) # put the xi back in
 
   return condense( ss1+ssmk )
 
 end
 
 # to multiply by a single w, default non-equivariant
-function mult_schub(f::Union{Int,ZZMPolyRingElem}, w::Vector{Int}, rnk::Int=length(w), R::Union{ZZMPolyRing,DoublePolyRing}=xy_ring(rnk-1)[1] )
+function mult_schub(f::Union{Int,ZZMPolyRingElem}, w::Vector{Int}, rnk::Int=length(w), R::Union{ZZMPolyRing,DoublePolyRing}=xy_ring(rnk-1)[1]; double::Bool=false )
   ss = SchubertSum(w)
-  return mult_schub(f,ss,rnk,R)
+  return mult_schub(f,ss,rnk,R; double=double)
 end
 
 
 
 # expand a polynomial in Schubert basis, default non-equivariant
-function expand_schub( f::Union{Int,ZZMPolyRingElem}, rnk::Int=maxvar( f ), R::Union{ZZMPolyRing,DoublePolyRing}=parent(f) )
+function expand_schub( f::Union{Int,ZZMPolyRingElem}, rnk::Int=maxvar( f ), R::Union{ZZMPolyRing,DoublePolyRing}=parent(f); double::Bool=false )
 
-  return mult_schub( f, [1], rnk, R )
+  return mult_schub( f, [1], rnk, R; double=double )
 
 end
 
@@ -138,7 +138,7 @@ function maxvar(f::Int)
 end
 
 
-function monk(ss::SchubertSum, i::Int, rnk::Int, R::Union{DoublePolyRing,ZZMPolyRing}=xy_ring(rnk)[1])
+function monk(ss::SchubertSum, i::Int, rnk::Int, R::Union{DoublePolyRing,ZZMPolyRing}=xy_ring(rnk)[1]; double::Bool=false)
 
   if i>rnk || i<0
     return(ss)
@@ -146,7 +146,7 @@ function monk(ss::SchubertSum, i::Int, rnk::Int, R::Union{DoublePolyRing,ZZMPoly
 
   ll = length(ss)
 
-  if isa(R, DoublePolyRing)
+  if double && isa(R, DoublePolyRing)
     yy = R.y_vars
   else
     yy = Int[]

--- a/src/schub_polys.jl
+++ b/src/schub_polys.jl
@@ -8,172 +8,133 @@ export schub_poly, groth_poly, nschub, ngroth, ddx, pdx
 #############
 
 """
-    schub_poly(w, R; method)
+    schub_poly(w; double=false, ring=schub_ring(length(w)-1, length(w)-1), method="auto", memo=false)
 
-Return the Schubert polynomial for the permutation `w`
+Return the Schubert polynomial for the permutation `w`.
 
 ## Arguments
 - `w::Vector{Int}`: A permutation
-- `R::DoublePolyRing`: The ambient polynomial ring, with underlying ring `R.ring` and variables `R.x_vars` and `R.y_vars`.  Optional; if omitted, a ring is chosen based on `double`.
-- `double::Bool`: An optional keyword (default `false`).  When `false`, the single Schubert polynomial is returned, using only the x-variables of `R` (any y-variables are ignored).  When `true`, the double/factorial Schubert polynomial is returned; `R` must then have y-variables.
-- `method`: An optional argument specifying the algorithm for computing.
-- `memo`: An optional argument for memoization (default=false)
+
+## Keywords
+- `double::Bool`: When `false` (default), the single Schubert polynomial is returned, using only the x-variables of `ring` (any y-variables are ignored).  When `true`, the double/factorial Schubert polynomial is returned; `ring` must then have y-variables.
+- `ring::MPolyRing`: The ambient polynomial ring (build with `schub_ring`; recover variables with `extract_vars`).  Defaults to `schub_ring(length(w)-1, length(w)-1)`.
+- `method`: The algorithm for computing.
+- `memo`: Memoization (default `false`).
 
 The options for `method` are:
 - `method="transition"`, computes via transition formula
 - `method="bpd"`, computes by summing over all BPDs
 - `method="dd"`, computes by divided differences from longest permutation
-- `method="auto" (default), computes by transition if `double` is requested, or if w has relatively small length, otherwise computes by divided difference
+- `method="auto"` (default), computes by transition if `double` is requested, or if w has relatively small length, otherwise computes by divided difference
 - `method="drift"` (deprecated), now aliased to `"bpd"`; drift methods have moved to DriftPolynomials.jl
 
 ## Returns
-`ZZMPolyRingElem`: the Schubert polynomial in the ring R
+`ZZMPolyRingElem`: the Schubert polynomial in `ring`
 
 ## Examples
 ```julia-repl
-# Define a single-variable DoublePolyRing
-julia> R = xy_ring(5,0)[1];
-
 # Choose a permutation
 julia> w = [3,5,1,4,2];
 
-# Compute via transition
-julia> pol1 = schub_poly(w, R, method="transition");
+# Compute via transition vs divided differences in a y-free ring
+julia> R = schub_ring(5,0);
 
-# Compute via divided differences
-julia> pol2 = schub_poly(w, R, method="dd");
-
-julia> pol1==pol2
+julia> schub_poly(w; ring=R, method="transition") == schub_poly(w; ring=R, method="dd")
 true
 ```
 
 ### If there are not enough x-variables to compute by descending induction, the "dd" method throws an error
 ```julia-repl
-julia> R = xy_ring(3,0)[1];
-
-julia> schub_poly(w, R, method="dd")
+julia> schub_poly(w; ring=schub_ring(3,0), method="dd")
 ERROR: ArgumentError: Not enough x variables for this method
-
 ```
 
-### If R is not specified, a ring containing the single Schubert polynomial is chosen
-
+### The double/factorial Schubert polynomial needs a ring with y-variables
 ```julia-repl
-julia> pol3 = schub_poly(w, method="bpd");
-
-julia> R,x,y = xy_ring(4,0);
-
-julia> pol4 = schub_poly(w, R, method="transition");
-
-julia> pol3==pol4
-true
+julia> p = schub_poly(w; ring=schub_ring(5,5), double=true);
 ```
 """
-# no ring supplied: choose a default ring based on `double`
-function schub_poly(w::Vector{Int}; double::Bool=false, method="auto", memo::Bool=false )
-  return schub_poly(w, default_ring( max(length(w)-1,1), double ); double=double, method=method, memo=memo )
-end
+function schub_poly(w::Vector{Int}; double::Bool=false,
+                    ring::MPolyRing=schub_ring( max(length(w)-1,1), max(length(w)-1,1) ),
+                    method="auto", memo::Bool=false )
 
-function schub_poly(w::Vector{Int}, R::DoublePolyRing; double::Bool=false, method="auto", memo::Bool=false )
-
-  double && length(R.y_vars)==0 && throw(ArgumentError("double=true requires a ring with y-variables; got a y-free ring"))
+  double && isempty(extract_vars(ring; varname=:y)) && throw(ArgumentError("double=true requires a ring with y-variables; got a y-free ring"))
 
   w=trimw(w)
   ws = cutw(w)
 
   if length(ws)>1
-    return( schub_poly(ws[1], R; double=double, method=method, memo=memo )*schub_poly(ws[2], R; double=double, method=method, memo=memo ) )
+    return( schub_poly(ws[1]; double=double, ring=ring, method=method, memo=memo )*schub_poly(ws[2]; double=double, ring=ring, method=method, memo=memo ) )
   end
 
   if memo
-    return schub_trans_memo(w,R; double=double)
+    return schub_trans_memo(w,ring; double=double)
   end
 
   if method=="dd"
-    return schub_dd(w,R; double=double)
+    return schub_dd(w,ring; double=double)
   elseif method=="bpd"
-    return schub_bpd(w,R; double=double)
+    return schub_bpd(w,ring; double=double)
   elseif method=="drift"
     Base.depwarn("the \"drift\" method is deprecated and now computes via \"bpd\"; drift methods have moved to DriftPolynomials.jl", :schub_poly)
-    return schub_bpd(w,R; double=double)
+    return schub_bpd(w,ring; double=double)
   elseif method=="transition"
-    return schub_trans(w,R; double=double)
+    return schub_trans(w,ring; double=double)
   end
 
   if double || len(w)<.3*length(w)^2
-    return schub_trans(w,R; double=double)
+    return schub_trans(w,ring; double=double)
   end
 
-  return schub_dd(w,R; double=double)
+  return schub_dd(w,ring; double=double)
 
 end
 
 
 """
-    groth_poly(w, R; method)
+    groth_poly(w; double=false, ring=schub_ring(length(w)-1, length(w)-1), method="dd")
 
-Return the Grothendieck polynomial for the permutation `w`
+Return the Grothendieck polynomial for the permutation `w`.
 
 ## Arguments
 - `w::Vector{Int}`: A permutation
-- `R::DoublePolyRing`: The ambient polynomial ring, with underlying ring `R.ring` and variables `R.x_vars` and `R.y_vars`.  Optional; if omitted, a ring is chosen based on `double`.
-- `double::Bool`: An optional keyword (default `false`).  When `false`, the single Grothendieck polynomial is returned, using only the x-variables of `R`.  When `true`, the double Grothendieck polynomial is returned; `R` must then have y-variables.
-- `method`: An optional argument specifying the algorithm for computing.
+
+## Keywords
+- `double::Bool`: When `false` (default), the single Grothendieck polynomial is returned, using only the x-variables of `ring`.  When `true`, the double Grothendieck polynomial is returned; `ring` must then have y-variables.
+- `ring::MPolyRing`: The ambient polynomial ring (build with `schub_ring`; recover variables with `extract_vars`).  Defaults to `schub_ring(length(w)-1, length(w)-1)`.
+- `method`: The algorithm for computing.
 
 The options for `method` are:
-- `method="bpd"` (default), computes by summing over all BPDs
-- `method="dd"`, computes by divided differences from longest permutation 
+- `method="dd"` (default), computes by divided differences from longest permutation
+- `method="bpd"`, computes by summing over all BPDs
 
 ## Returns
-`ZZMPolyRingElem`: the Grothendieck polynomial in the ring R
+`ZZMPolyRingElem`: the Grothendieck polynomial in `ring`
 
 ## Examples
 ```julia-repl
-# Define a single-variable DoublePolyRing
-julia> R,x,y = xy_ring(5,0);
-
-# Choose a permutation
 julia> w = [3,5,1,4,2];
 
-# Compute via divided differences (default)
-julia> pol1 = groth_poly(w, R);
+julia> R = schub_ring(5,0);
 
-# Compute via bpds
-julia> pol2 = groth_poly(w, R, method="bpd");
-
-julia> pol1==pol2
-true
-```
-### If R is not specified, a polynomial ring containing the single Grothendieck polynomial is chosen
-
-```julia-repl
-julia> pol3 = groth_poly(w, method="bpd");
-
-julia> R,x,y = xy_ring(4,0);
-
-julia> pol4 = groth_poly(w, R, method="dd");
-
-julia> pol3==pol4
+julia> groth_poly(w; ring=R) == groth_poly(w; ring=R, method="bpd")
 true
 ```
 """
-# no ring supplied: choose a default ring based on `double`
-function groth_poly(w::Vector{Int}; double::Bool=false, method="dd" )
-  return groth_poly(w, default_ring( max(length(w)-1,1), double ); double=double, method=method )
-end
+function groth_poly(w::Vector{Int}; double::Bool=false,
+                    ring::MPolyRing=schub_ring( max(length(w)-1,1), max(length(w)-1,1) ),
+                    method="dd" )
 
-function groth_poly(w::Vector{Int}, R::DoublePolyRing; double::Bool=false, method="dd" )
-
-  double && length(R.y_vars)==0 && throw(ArgumentError("double=true requires a ring with y-variables; got a y-free ring"))
+  double && isempty(extract_vars(ring; varname=:y)) && throw(ArgumentError("double=true requires a ring with y-variables; got a y-free ring"))
 
   if method=="dd"
-    return groth_dd(w,R; double=double)
+    return groth_dd(w,ring; double=double)
   elseif method=="drift"
     Base.depwarn("the \"drift\" method is deprecated and now computes via \"bpd\"; drift methods have moved to DriftPolynomials.jl", :groth_poly)
-    return groth_bpd(w,R; double=double)
+    return groth_bpd(w,ring; double=double)
   end
 
-  return groth_bpd(w,R; double=double)
+  return groth_bpd(w,ring; double=double)
 
 end
 
@@ -231,26 +192,25 @@ function ngroth(w::Vector{Int})
 
   n = length(w)-1
 
-  R = xy_ring(n,0)[1]
+  R = schub_ring(n,0)
 
-  pw = groth_poly(w,R,method="dd")
+  pw = groth_poly(w; ring=R, method="dd")
 
-  return sum(abs.(coefficients(pw)))  
+  return sum(abs.(coefficients(pw)))
 
 end
 
 ######
 
 
-function bpd2bin( bpd::BPD, R::DoublePolyRing=xy_ring( size(bpd.mtx)[1]-1, size(bpd.mtx)[2]-1 )[1]; version="schub", double::Bool=false  )
+function bpd2bin( bpd::BPD, R::MPolyRing=schub_ring( size(bpd.mtx)[1]-1, size(bpd.mtx)[2]-1 ); version="schub", double::Bool=false  )
 # product of binomials for bpd
-# requires DoublePolyRing
 # `double=false` (default) ignores any y-variables, giving the single polynomial
   local n=size(bpd.mtx)[1]-1
-  bin = R.ring(1)
+  bin = R(1)
 
-  x = R.x_vars
-  y = R.y_vars
+  x = extract_vars(R; varname=:x)
+  y = extract_vars(R; varname=:y)
 
   local aa=length(x)
   local bb= double ? length(y) : 0
@@ -259,7 +219,7 @@ function bpd2bin( bpd::BPD, R::DoublePolyRing=xy_ring( size(bpd.mtx)[1]-1, size(
     for j=1:n
 
       if bpd.mtx[i,j]==0
-        p=R.ring(0)
+        p=R(0)
         if i<=aa
           p=p+x[i]
         end
@@ -268,7 +228,7 @@ function bpd2bin( bpd::BPD, R::DoublePolyRing=xy_ring( size(bpd.mtx)[1]-1, size(
         end
         if version=="groth" && i<=aa && j<=bb
           p=p-x[i]*y[j]
-        end     
+        end
         bin = bin*p
         if version=="groth"
           bin = -bin
@@ -276,7 +236,7 @@ function bpd2bin( bpd::BPD, R::DoublePolyRing=xy_ring( size(bpd.mtx)[1]-1, size(
       end
 
       if version=="groth" && bpd.mtx[i,j]==3
-        p=R.ring(1)
+        p=R(1)
         if i<=aa
           p=p-x[i]
         end
@@ -285,7 +245,7 @@ function bpd2bin( bpd::BPD, R::DoublePolyRing=xy_ring( size(bpd.mtx)[1]-1, size(
         end
         if i<=aa && j<=bb
           p=p+x[i]*y[j]
-        end     
+        end
         bin = bin*p
       end
 
@@ -298,11 +258,11 @@ end
 
 
 
-function schub_bpd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]; double::Bool=false  )
+function schub_bpd( w::Vector{Int}, R::MPolyRing=schub_ring( max(length(w)-1,1), max(length(w)-1,1) ); double::Bool=false  )
 # compute schubert pol by bpd formula
   bpds=all_bpds(w)
 
-  pol=R.ring(0)
+  pol=R(0)
 
   for bp in bpds
     pol = pol+bpd2bin(bp,R; double=double)
@@ -315,7 +275,7 @@ end
 
 
 #@memoize
-function schub_trans( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]; double::Bool=false )
+function schub_trans( w::Vector{Int}, R::MPolyRing=schub_ring( max(length(w)-1,1), max(length(w)-1,1) ); double::Bool=false )
 # compute schubert pol by transition formula
 
   mxt = max_transition(w)
@@ -331,12 +291,12 @@ function schub_trans( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1
   vv = mxt[2]
   wws = mxt[3]
 
-  x = R.x_vars
-  y = R.y_vars
+  x = extract_vars(R; varname=:x)
+  y = extract_vars(R; varname=:y)
 
   pv = schub_trans(vv, R; double=double)
 
-  p1 = R.ring(0)
+  p1 = R(0)
 
   if r<=length(x)
     p1 = p1+x[r]
@@ -357,7 +317,7 @@ function schub_trans( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1
 
 end
 
-@memoize function schub_trans_memo( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]; double::Bool=false )
+@memoize function schub_trans_memo( w::Vector{Int}, R::MPolyRing=schub_ring( max(length(w)-1,1), max(length(w)-1,1) ); double::Bool=false )
 # compute schubert pol by transition formula, memoized
 
   mxt = max_transition(w)
@@ -373,12 +333,12 @@ end
   vv = mxt[2]
   wws = mxt[3]
 
-  x = R.x_vars
-  y = R.y_vars
+  x = extract_vars(R; varname=:x)
+  y = extract_vars(R; varname=:y)
 
   pv = schub_trans_memo(vv, R; double=double)
 
-  p1 = R.ring(0)
+  p1 = R(0)
 
   if r<=length(x)
     p1 = p1+x[r]
@@ -400,7 +360,7 @@ end
 end
 
 
-function schub_dd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]; double::Bool=false )
+function schub_dd( w::Vector{Int}, R::MPolyRing=schub_ring( max(length(w)-1,1), max(length(w)-1,1) ); double::Bool=false )
 # compute schubert pol by divided differences
 
   w=trimw(w)
@@ -408,10 +368,10 @@ function schub_dd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1)
   n=length(w)
 
   if n==0
-    return(R.ring(1))
+    return(R(1))
   end
 
-  if length(R.x_vars)<n-1
+  if length(extract_vars(R; varname=:x))<n-1
     throw(ArgumentError("Not enough x variables for this method"))
   end
 
@@ -434,11 +394,11 @@ end
 
 
 
-function groth_bpd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]; double::Bool=false  )
+function groth_bpd( w::Vector{Int}, R::MPolyRing=schub_ring( max(length(w)-1,1), max(length(w)-1,1) ); double::Bool=false  )
 # compute grothendieck pol by bpd formula
   bpds=all_Kbpds(w)
 
-  pol=R.ring(0)
+  pol=R(0)
 
   for bp in bpds
     pol = pol+bpd2bin(bp,R; version="groth", double=double)
@@ -449,7 +409,7 @@ function groth_bpd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1
 end
 
 
-@memoize function groth_dd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]; double::Bool=false )
+@memoize function groth_dd( w::Vector{Int}, R::MPolyRing=schub_ring( max(length(w)-1,1), max(length(w)-1,1) ); double::Bool=false )
 # compute grothendieck pol by divided differences
 
   n=length(w)
@@ -459,10 +419,10 @@ end
   end
 
   if n==0
-    return(R.ring(1))
+    return(R(1))
   end
 
-  if length(R.x_vars)<n-1
+  if length(extract_vars(R; varname=:x))<n-1
     throw(ArgumentError("Not enough x variables for this method"))
   end
 
@@ -489,10 +449,10 @@ end
 
 #############
 
-function sp0( n::Int, R::DoublePolyRing=xy_ring( n-1, n-1 )[1]; double::Bool=false )
+function sp0( n::Int, R::MPolyRing=schub_ring( n-1, n-1 ); double::Bool=false )
 
-  x=R.x_vars
-  y=R.y_vars
+  x=extract_vars(R; varname=:x)
+  y=extract_vars(R; varname=:y)
 
   aa=length(x)
   bb= double ? length(y) : 0
@@ -501,7 +461,7 @@ function sp0( n::Int, R::DoublePolyRing=xy_ring( n-1, n-1 )[1]; double::Bool=fal
 
   for i in 1:n-1
     for j in 1:n-i
-      p=R.ring(0)
+      p=R(0)
       if i<=aa p=p+x[i] end
       if j<=bb p=p+y[j] end
       pol = pol*p
@@ -513,10 +473,10 @@ function sp0( n::Int, R::DoublePolyRing=xy_ring( n-1, n-1 )[1]; double::Bool=fal
 end
 
 
-function gp0( n::Int, R::DoublePolyRing=xy_ring( n-1, n-1 )[1]; double::Bool=false )
+function gp0( n::Int, R::MPolyRing=schub_ring( n-1, n-1 ); double::Bool=false )
 
-  x=R.x_vars
-  y=R.y_vars
+  x=extract_vars(R; varname=:x)
+  y=extract_vars(R; varname=:y)
 
   aa=length(x)
   bb= double ? length(y) : 0
@@ -525,7 +485,7 @@ function gp0( n::Int, R::DoublePolyRing=xy_ring( n-1, n-1 )[1]; double::Bool=fal
 
   for i in 1:n-1
     for j in 1:n-i
-      p=R.ring(0)
+      p=R(0)
       if i<=aa p=p+x[i] end
       if j<=bb p=p+y[j] end
       if i<=aa && j<=bb p=p-x[i]*y[j] end
@@ -543,16 +503,11 @@ end
 #####################
 # difference operator
 
-function ddx(p::ZZMPolyRingElem, i::Int, R::Union{ZZMPolyRing,DoublePolyRing}=parent(p))
-# p is a polynomial in R.x_vars
+function ddx(p::ZZMPolyRingElem, i::Int, R::MPolyRing=parent(p))
+# p is a polynomial in the x-variables of R
 
-  if isa(R,ZZMPolyRing)
-    RR = R
-    x = gens(R)
-  elseif isa(R,DoublePolyRing)
-    RR = R.ring
-    x = R.x_vars
-  end
+  RR = R
+  x = extract_vars(R; varname=:x)
 
   if i>length(x)
     return(RR(0))
@@ -574,16 +529,11 @@ end
 
 
 # isobaric difference operator
-function pdx(p::ZZMPolyRingElem, i::Int, R::Union{ZZMPolyRing,DoublePolyRing}=parent(p))
-# p is a polynomial in R.x_vars
+function pdx(p::ZZMPolyRingElem, i::Int, R::MPolyRing=parent(p))
+# p is a polynomial in the x-variables of R
 
-  if isa(R,ZZMPolyRing)
-    RR = R
-    x = gens(R)
-  elseif isa(R,DoublePolyRing)
-    RR = R.ring
-    x = R.x_vars
-  end
+  RR = R
+  x = extract_vars(R; varname=:x)
 
   if i>length(x)
     return(p)

--- a/src/schub_polys.jl
+++ b/src/schub_polys.jl
@@ -21,10 +21,10 @@ Return the Schubert polynomial for the permutation `w`
 
 The options for `method` are:
 - `method="transition"`, computes via transition formula
-- `method="drift"`, computes from flat BPDs by drift class formula
 - `method="bpd"`, computes by summing over all BPDs
-- `method="dd"`, computes by divided differences from longest permutation 
-- `method="auto" (default), computes by transition if there are y variables, or if w has relatively small length, otherwise computes by divided difference
+- `method="dd"`, computes by divided differences from longest permutation
+- `method="auto" (default), computes by transition if `double` is requested, or if w has relatively small length, otherwise computes by divided difference
+- `method="drift"` (deprecated), now aliased to `"bpd"`; drift methods have moved to DriftPolynomials.jl
 
 ## Returns
 `ZZMPolyRingElem`: the Schubert polynomial in the ring R
@@ -56,14 +56,14 @@ ERROR: ArgumentError: Not enough x variables for this method
 
 ```
 
-### If R is not specified, a double polynomial ring containing the single Schubert polynomial is chosen
+### If R is not specified, a ring containing the single Schubert polynomial is chosen
 
 ```julia-repl
 julia> pol3 = schub_poly(w, method="bpd");
 
 julia> R,x,y = xy_ring(4,0);
 
-julia> pol4 = schub_poly(w, R, method="drift");
+julia> pol4 = schub_poly(w, R, method="transition");
 
 julia> pol3==pol4
 true
@@ -94,7 +94,8 @@ function schub_poly(w::Vector{Int}, R::DoublePolyRing; double::Bool=false, metho
   elseif method=="bpd"
     return schub_bpd(w,R; double=double)
   elseif method=="drift"
-    return schub_drifts(w,R; double=double)
+    Base.depwarn("the \"drift\" method is deprecated and now computes via \"bpd\"; drift methods have moved to DriftPolynomials.jl", :schub_poly)
+    return schub_bpd(w,R; double=double)
   elseif method=="transition"
     return schub_trans(w,R; double=double)
   end
@@ -168,7 +169,8 @@ function groth_poly(w::Vector{Int}, R::DoublePolyRing; double::Bool=false, metho
   if method=="dd"
     return groth_dd(w,R; double=double)
   elseif method=="drift"
-    return groth_drifts(w,R; double=double)
+    Base.depwarn("the \"drift\" method is deprecated and now computes via \"bpd\"; drift methods have moved to DriftPolynomials.jl", :groth_poly)
+    return groth_bpd(w,R; double=double)
   end
 
   return groth_bpd(w,R; double=double)
@@ -177,7 +179,6 @@ end
 
 
 ## TO DO: add "transition" method for groth_poly
-## TO DO: figure out "drift" method for groth_poly
 
 
 ######
@@ -320,7 +321,10 @@ function schub_trans( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1
   mxt = max_transition(w)
 
   if length(mxt)==0
-    return schub_drifts(w,R; double=double)
+    # max_transition is empty exactly for dominant permutations, whose Schubert
+    # polynomial is the single flat (Rothe) BPD; sum over BPDs gives the answer
+    # directly, with no need for the (removed) drift machinery.
+    return schub_bpd(w,R; double=double)
   end
 
   (r,s) = mxt[1]
@@ -359,7 +363,10 @@ end
   mxt = max_transition(w)
 
   if length(mxt)==0
-    return schub_drifts(w,R; double=double)
+    # max_transition is empty exactly for dominant permutations, whose Schubert
+    # polynomial is the single flat (Rothe) BPD; sum over BPDs gives the answer
+    # directly, with no need for the (removed) drift machinery.
+    return schub_bpd(w,R; double=double)
   end
 
   (r,s) = mxt[1]
@@ -618,26 +625,3 @@ function vex_det( la::Vector{Int}, ff::Vector{Int} )
   return det(A)
 
 end
-
-
-
-
-#=
-# temporary alternative, not used
-function schub_2drifts( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1] )
-# compute schubert pol by drift class formula
-
-  fbpds = flat_bpds(w)
-
-  pol = R.ring(0)
-
-  for b in fbpds
-    d=bpd2drift(b)
-    pol = pol+drift_poly(d,R)
-  end
-
-  return pol
-
-end
-
-=#

--- a/src/schub_polys.jl
+++ b/src/schub_polys.jl
@@ -14,7 +14,8 @@ Return the Schubert polynomial for the permutation `w`
 
 ## Arguments
 - `w::Vector{Int}`: A permutation
-- `R::DoublePolyRing`: The ambient polynomial ring, with underlying ring `R.ring` and variables `R.x_vars` and `R.y_vars`
+- `R::DoublePolyRing`: The ambient polynomial ring, with underlying ring `R.ring` and variables `R.x_vars` and `R.y_vars`.  Optional; if omitted, a ring is chosen based on `double`.
+- `double::Bool`: An optional keyword (default `false`).  When `false`, the single Schubert polynomial is returned, using only the x-variables of `R` (any y-variables are ignored).  When `true`, the double/factorial Schubert polynomial is returned; `R` must then have y-variables.
 - `method`: An optional argument specifying the algorithm for computing.
 - `memo`: An optional argument for memoization (default=false)
 
@@ -68,34 +69,41 @@ julia> pol3==pol4
 true
 ```
 """
-function schub_poly(w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1) )[1]; method="auto", memo::Bool=false )
+# no ring supplied: choose a default ring based on `double`
+function schub_poly(w::Vector{Int}; double::Bool=false, method="auto", memo::Bool=false )
+  return schub_poly(w, default_ring( max(length(w)-1,1), double ); double=double, method=method, memo=memo )
+end
+
+function schub_poly(w::Vector{Int}, R::DoublePolyRing; double::Bool=false, method="auto", memo::Bool=false )
+
+  double && length(R.y_vars)==0 && throw(ArgumentError("double=true requires a ring with y-variables; got a y-free ring"))
 
   w=trimw(w)
   ws = cutw(w)
 
   if length(ws)>1
-    return( schub_poly(ws[1], R; method=method, memo=memo )*schub_poly(ws[2], R; method=method, memo=memo ) ) 
+    return( schub_poly(ws[1], R; double=double, method=method, memo=memo )*schub_poly(ws[2], R; double=double, method=method, memo=memo ) )
   end
 
   if memo
-    return schub_trans_memo(w,R)
+    return schub_trans_memo(w,R; double=double)
   end
 
   if method=="dd"
-    return schub_dd(w,R)
+    return schub_dd(w,R; double=double)
   elseif method=="bpd"
-    return schub_bpd(w,R)
+    return schub_bpd(w,R; double=double)
   elseif method=="drift"
-    return schub_drifts(w,R)
+    return schub_drifts(w,R; double=double)
   elseif method=="transition"
-    return schub_trans(w,R)
+    return schub_trans(w,R; double=double)
   end
 
-  if length(R.y_vars)>0 || len(w)<.3*length(w)^2
-    return schub_trans(w,R)
+  if double || len(w)<.3*length(w)^2
+    return schub_trans(w,R; double=double)
   end
 
-  return schub_dd(w,R)
+  return schub_dd(w,R; double=double)
 
 end
 
@@ -107,7 +115,8 @@ Return the Grothendieck polynomial for the permutation `w`
 
 ## Arguments
 - `w::Vector{Int}`: A permutation
-- `R::DoublePolyRing`: The ambient polynomial ring, with underlying ring `R.ring` and variables `R.x_vars` and `R.y_vars`
+- `R::DoublePolyRing`: The ambient polynomial ring, with underlying ring `R.ring` and variables `R.x_vars` and `R.y_vars`.  Optional; if omitted, a ring is chosen based on `double`.
+- `double::Bool`: An optional keyword (default `false`).  When `false`, the single Grothendieck polynomial is returned, using only the x-variables of `R`.  When `true`, the double Grothendieck polynomial is returned; `R` must then have y-variables.
 - `method`: An optional argument specifying the algorithm for computing.
 
 The options for `method` are:
@@ -147,15 +156,22 @@ julia> pol3==pol4
 true
 ```
 """
-function groth_poly(w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), 0 )[1]; method="dd" )
+# no ring supplied: choose a default ring based on `double`
+function groth_poly(w::Vector{Int}; double::Bool=false, method="dd" )
+  return groth_poly(w, default_ring( max(length(w)-1,1), double ); double=double, method=method )
+end
+
+function groth_poly(w::Vector{Int}, R::DoublePolyRing; double::Bool=false, method="dd" )
+
+  double && length(R.y_vars)==0 && throw(ArgumentError("double=true requires a ring with y-variables; got a y-free ring"))
 
   if method=="dd"
-    return groth_dd(w,R)
+    return groth_dd(w,R; double=double)
   elseif method=="drift"
-    return groth_drifts(w,R)
+    return groth_drifts(w,R; double=double)
   end
 
-  return groth_bpd(w,R)
+  return groth_bpd(w,R; double=double)
 
 end
 
@@ -225,10 +241,10 @@ end
 ######
 
 
-function bpd2bin( bpd::BPD, R::DoublePolyRing=xy_ring( size(bpd.mtx)[1]-1, size(bpd.mtx)[2]-1 )[1]; version="schub"  )
+function bpd2bin( bpd::BPD, R::DoublePolyRing=xy_ring( size(bpd.mtx)[1]-1, size(bpd.mtx)[2]-1 )[1]; version="schub", double::Bool=false  )
 # product of binomials for bpd
 # requires DoublePolyRing
-# can get single polyn by using no y_vars
+# `double=false` (default) ignores any y-variables, giving the single polynomial
   local n=size(bpd.mtx)[1]-1
   bin = R.ring(1)
 
@@ -236,7 +252,7 @@ function bpd2bin( bpd::BPD, R::DoublePolyRing=xy_ring( size(bpd.mtx)[1]-1, size(
   y = R.y_vars
 
   local aa=length(x)
-  local bb=length(y)
+  local bb= double ? length(y) : 0
 
   for i=1:n
     for j=1:n
@@ -281,14 +297,14 @@ end
 
 
 
-function schub_bpd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]  )
+function schub_bpd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]; double::Bool=false  )
 # compute schubert pol by bpd formula
   bpds=all_bpds(w)
 
   pol=R.ring(0)
 
   for bp in bpds
-    pol = pol+bpd2bin(bp,R)
+    pol = pol+bpd2bin(bp,R; double=double)
   end
 
   return(pol)
@@ -297,14 +313,14 @@ end
 
 
 
-#@memoize 
-function schub_trans( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1] )
+#@memoize
+function schub_trans( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]; double::Bool=false )
 # compute schubert pol by transition formula
 
   mxt = max_transition(w)
 
   if length(mxt)==0
-    return schub_drifts(w,R)
+    return schub_drifts(w,R; double=double)
   end
 
   (r,s) = mxt[1]
@@ -314,7 +330,7 @@ function schub_trans( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1
   x = R.x_vars
   y = R.y_vars
 
-  pv = schub_trans(vv, R)
+  pv = schub_trans(vv, R; double=double)
 
   p1 = R.ring(0)
 
@@ -322,14 +338,14 @@ function schub_trans( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1
     p1 = p1+x[r]
   end
 
-  if w[s]<=length(y)
+  if double && w[s]<=length(y)
     p1 = p1 + y[w[s]]
   end
 
   p1 = p1*pv
 
   for ww in wws
-    pw = schub_trans(ww,R)
+    pw = schub_trans(ww,R; double=double)
     p1 = p1+pw
   end
 
@@ -337,13 +353,13 @@ function schub_trans( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1
 
 end
 
-@memoize function schub_trans_memo( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1] )
+@memoize function schub_trans_memo( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]; double::Bool=false )
 # compute schubert pol by transition formula, memoized
 
   mxt = max_transition(w)
 
   if length(mxt)==0
-    return schub_drifts(w,R)
+    return schub_drifts(w,R; double=double)
   end
 
   (r,s) = mxt[1]
@@ -353,7 +369,7 @@ end
   x = R.x_vars
   y = R.y_vars
 
-  pv = schub_trans_memo(vv, R)
+  pv = schub_trans_memo(vv, R; double=double)
 
   p1 = R.ring(0)
 
@@ -361,14 +377,14 @@ end
     p1 = p1+x[r]
   end
 
-  if w[s]<=length(y)
+  if double && w[s]<=length(y)
     p1 = p1 + y[w[s]]
   end
 
   p1 = p1*pv
 
   for ww in wws
-    pw = schub_trans_memo(ww,R)
+    pw = schub_trans_memo(ww,R; double=double)
     p1 = p1+pw
   end
 
@@ -377,7 +393,7 @@ end
 end
 
 
-function schub_dd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1] )
+function schub_dd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]; double::Bool=false )
 # compute schubert pol by divided differences
 
   w=trimw(w)
@@ -398,12 +414,12 @@ function schub_dd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1)
   end
 
   if i==0
-    return sp0( n, R )
+    return sp0( n, R; double=double )
   end
 
   w = vcat( w[1:i-1], w[i+1], w[i], w[i+2:n] )
 
-  pol1 = schub_dd( w, R )
+  pol1 = schub_dd( w, R; double=double )
 
   return ddx( pol1, i, R )
 
@@ -411,14 +427,14 @@ end
 
 
 
-function groth_bpd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]  )
+function groth_bpd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]; double::Bool=false  )
 # compute grothendieck pol by bpd formula
   bpds=all_Kbpds(w)
 
   pol=R.ring(0)
 
   for bp in bpds
-    pol = pol+bpd2bin(bp,R, version="groth")
+    pol = pol+bpd2bin(bp,R; version="groth", double=double)
   end
 
   return((-1)^len(w)*pol)
@@ -426,7 +442,7 @@ function groth_bpd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1
 end
 
 
-@memoize function groth_dd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1] )
+@memoize function groth_dd( w::Vector{Int}, R::DoublePolyRing=xy_ring( max(length(w)-1,1), max(length(w)-1,1) )[1]; double::Bool=false )
 # compute grothendieck pol by divided differences
 
   n=length(w)
@@ -449,12 +465,12 @@ end
   end
 
   if i==0
-    return gp0( n, R )
+    return gp0( n, R; double=double )
   end
 
   w = vcat( w[1:i-1], w[i+1], w[i], w[i+2:n] )
 
-  pol1 = groth_dd( w, R )
+  pol1 = groth_dd( w, R; double=double )
 
   return pdx( pol1, i, R )
 
@@ -466,13 +482,13 @@ end
 
 #############
 
-function sp0( n::Int, R::DoublePolyRing=xy_ring( n-1, n-1 )[1] )
+function sp0( n::Int, R::DoublePolyRing=xy_ring( n-1, n-1 )[1]; double::Bool=false )
 
   x=R.x_vars
   y=R.y_vars
 
   aa=length(x)
-  bb=length(y)
+  bb= double ? length(y) : 0
 
   pol=1
 
@@ -490,13 +506,13 @@ function sp0( n::Int, R::DoublePolyRing=xy_ring( n-1, n-1 )[1] )
 end
 
 
-function gp0( n::Int, R::DoublePolyRing=xy_ring( n-1, n-1 )[1] )
+function gp0( n::Int, R::DoublePolyRing=xy_ring( n-1, n-1 )[1]; double::Bool=false )
 
   x=R.x_vars
   y=R.y_vars
 
   aa=length(x)
-  bb=length(y)
+  bb= double ? length(y) : 0
 
   pol=1
 

--- a/src/specialize.jl
+++ b/src/specialize.jl
@@ -9,12 +9,12 @@ export localization, principal_specialization
 #########
 
 
-function localization( u::Vector{Int}, v::Vector{Int}, R::DoublePolyRing=xy_ring( length(v),length(v) )[1] )
+function localization( u::Vector{Int}, v::Vector{Int}, R::DoublePolyRing=xy_ring( length(v),length(v) )[1]; double::Bool=true )
 # localize Schubert class u at fixed point v
   x=R.x_vars
   y=R.y_vars
 
-  uu=trimw(u) 
+  uu=trimw(u)
   vv=trimw(v)
 
   if length(x)<length(vv) || length(y)<length(vv)
@@ -27,7 +27,7 @@ function localization( u::Vector{Int}, v::Vector{Int}, R::DoublePolyRing=xy_ring
 
   yv = [ -y[vi] for vi in vv ]
 
-  sp = schub_poly(uu,R)
+  sp = schub_poly(uu,R; double=double)
 
   spv = evaluate( sp, x[1:length(vv)], yv )
 
@@ -57,14 +57,14 @@ function principal_specialization( pol::ZZMPolyRingElem, R::Union{ZZMPolyRing,Do
 end
 
 
-function principal_specialization( w::Vector{Int}, R::DoublePolyRing=xy_ring(length(w)-1)[1] )
+function principal_specialization( w::Vector{Int}, R::DoublePolyRing=xy_ring(length(w)-1)[1]; double::Bool=false )
 # return principal specialization of Schubert polynomial for w
 
   if length(R.y_vars)>0
     throw(ArgumentError("no y variables allowed"))
   end
 
-  spw = schub_poly( w, R )
+  spw = schub_poly( w, R; double=double )
 
   spq = principal_specialization( spw, R )
 

--- a/src/specialize.jl
+++ b/src/specialize.jl
@@ -9,10 +9,11 @@ export localization, principal_specialization
 #########
 
 
-function localization( u::Vector{Int}, v::Vector{Int}, R::DoublePolyRing=xy_ring( length(v),length(v) )[1]; double::Bool=true )
+function localization( u::Vector{Int}, v::Vector{Int};
+                       double::Bool=true, ring::MPolyRing=schub_ring( length(v), length(v) ) )
 # localize Schubert class u at fixed point v
-  x=R.x_vars
-  y=R.y_vars
+  x=extract_vars(ring; varname=:x)
+  y=extract_vars(ring; varname=:y)
 
   uu=trimw(u)
   vv=trimw(v)
@@ -27,7 +28,7 @@ function localization( u::Vector{Int}, v::Vector{Int}, R::DoublePolyRing=xy_ring
 
   yv = [ -y[vi] for vi in vv ]
 
-  sp = schub_poly(uu,R; double=double)
+  sp = schub_poly(uu; ring=ring, double=double)
 
   spv = evaluate( sp, x[1:length(vv)], yv )
 
@@ -36,15 +37,10 @@ function localization( u::Vector{Int}, v::Vector{Int}, R::DoublePolyRing=xy_ring
 end
 
 
-function principal_specialization( pol::ZZMPolyRingElem, R::Union{ZZMPolyRing,DoublePolyRing}=parent(pol) )
+function principal_specialization( pol::ZZMPolyRingElem; ring::MPolyRing=parent(pol) )
 
-   if isa(R,DoublePolyRing)
-     RR = R.ring
-     xx = R.x_vars
-   else
-     RR = R
-     xx = gens(R)
-   end
+   RR = ring
+   xx = extract_vars(ring; varname=:x)
 
    S,qq = polynomial_ring(RR,[:q])
 
@@ -57,16 +53,17 @@ function principal_specialization( pol::ZZMPolyRingElem, R::Union{ZZMPolyRing,Do
 end
 
 
-function principal_specialization( w::Vector{Int}, R::DoublePolyRing=xy_ring(length(w)-1)[1]; double::Bool=false )
+function principal_specialization( w::Vector{Int}; double::Bool=false,
+                                   ring::MPolyRing=schub_ring(length(w)-1, 0) )
 # return principal specialization of Schubert polynomial for w
 
-  if length(R.y_vars)>0
+  if length(extract_vars(ring; varname=:y))>0
     throw(ArgumentError("no y variables allowed"))
   end
 
-  spw = schub_poly( w, R; double=double )
+  spw = schub_poly( w; ring=ring, double=double )
 
-  spq = principal_specialization( spw, R )
+  spq = principal_specialization( spw; ring=ring )
 
   return spq
 

--- a/src/ssyt.jl
+++ b/src/ssyt.jl
@@ -337,12 +337,12 @@ x1^2*x2 + x1^2*x3 + x1*x2^2 + 2*x1*x2*x3 + x1*x3^2 + x2^2*x3 + x2*x3^2
 
 ```
 """
-function schur_poly( la, ff::Vector{Vector{Int}}, RR::DoublePolyRing=xy_ring( length(la) , length(la)+la[1] )[1]; mu = Int[], xoffset=0, yoffset=0, rowmin=false )
+function schur_poly( la, ff::Vector{Vector{Int}}, RR::DoublePolyRing=xy_ring( length(la) , length(la)+la[1] )[1]; double::Bool=length(RR.y_vars)>0, mu = Int[], xoffset=0, yoffset=0, rowmin=false )
   if length(la)==0
     return RR.ring(1)
   end
 
-  if length(RR.y_vars)==0
+  if !double
      return schur_polynomial1_combinat( la, ff, RR, mu=mu, xoffset=xoffset, rowmin=rowmin )
   end
 
@@ -355,22 +355,22 @@ function schur_poly( la, ff::Vector{Vector{Int}}, RR::DoublePolyRing=xy_ring( le
 end
 
 ###
-function schur_poly( la, ff::Vector{Int}, RR::DoublePolyRing=xy_ring( length(la) , length(la)+la[1] )[1]; mu = Int[], xoffset=0, yoffset=0, rowmin=false )
+function schur_poly( la, ff::Vector{Int}, RR::DoublePolyRing=xy_ring( length(la) , length(la)+la[1] )[1]; double::Bool=length(RR.y_vars)>0, mu = Int[], xoffset=0, yoffset=0, rowmin=false )
   if length(la)==0
     return RR.ring(1)
   end
 
-  return schur_poly( la, Vector{Vector{Int}}([fill(ff[i],la[i]) for i=1:length(la)]), RR; mu = mu, xoffset=xoffset, yoffset=yoffset, rowmin=rowmin )
+  return schur_poly( la, Vector{Vector{Int}}([fill(ff[i],la[i]) for i=1:length(la)]), RR; double=double, mu = mu, xoffset=xoffset, yoffset=yoffset, rowmin=rowmin )
 
 end
 
 ###
-function schur_poly( la, ff::Int, RR::DoublePolyRing=xy_ring( length(la) , length(la)+la[1] )[1]; mu = Int[], xoffset=0, yoffset=0, rowmin=false )
+function schur_poly( la, ff::Int, RR::DoublePolyRing=xy_ring( length(la) , length(la)+la[1] )[1]; double::Bool=length(RR.y_vars)>0, mu = Int[], xoffset=0, yoffset=0, rowmin=false )
   if length(la)==0
     return RR.ring(1)
   end
 
-  return schur_poly( la, Vector{Int}(fill(ff,length(la))), RR; mu = mu, xoffset=xoffset, yoffset=yoffset, rowmin=rowmin )
+  return schur_poly( la, Vector{Int}(fill(ff,length(la))), RR; double=double, mu = mu, xoffset=xoffset, yoffset=yoffset, rowmin=rowmin )
 end
 
 
@@ -396,7 +396,9 @@ function schur_polynomial1_combinat(lambda::Vector{Int}, ff::Vector{Vector{Int}}
   mu = vcat(mu, [0 for s=length(mu)+1:len])  # extend mu by 0 if necessary
 
 
-  count = zeros(Int,length(xx))
+  # exponent vectors must span every variable of R.ring (the ring may carry
+  # y-variables we are ignoring for the single polynomial); x are the first gens
+  count = zeros(Int, nvars(R.ring))
   valid = true
   while true
     count .= 0

--- a/test/double_poly_ring.jl
+++ b/test/double_poly_ring.jl
@@ -1,35 +1,33 @@
-@testset "DoublePolyRing" begin
+@testset "schub_ring" begin
 
-aa=["a$(i)" for i=1:4]
-bb=["b$(i)" for i=1:3]
+# schub_ring returns a bare MPolyRing; variables recovered via extract_vars
+R = schub_ring(4,3)
 
-R,x,y=xy_ring(aa,bb)
+@test nvars(R)==7
+@test isa(extract_vars(R; varname=:x), Vector{ZZMPolyRingElem})
+@test isa(extract_vars(R; varname=:y), Vector{ZZMPolyRingElem})
+@test length(extract_vars(R; varname=:x))==4
+@test length(extract_vars(R; varname=:y))==3
 
-@test isa(x,Vector{ZZMPolyRingElem})
-@test isa(y,Vector{ZZMPolyRingElem})
-@test x==R.x_vars
-@test y==R.y_vars
-@test nvars(R.ring)==7
+R = schub_ring(4)
 
-R,x,y=xy_ring(aa)
+@test nvars(R)==4
+@test length(extract_vars(R; varname=:x))==4
+@test length(extract_vars(R; varname=:y))==0
 
-@test isa(x,Vector{ZZMPolyRingElem})
-@test length(y)==0
-@test nvars(R.ring)==4
+# coefficient ring keyword
+@test base_ring(schub_ring(3; coeff=QQ)) == QQ
 
+# custom variable names
+Rab = schub_ring(2,2; xname=:a, yname=:b)
+@test length(extract_vars(Rab; varname=:a))==2
+@test length(extract_vars(Rab; varname=:b))==2
 
-R,x,y=xy_ring(4,3)
-
-@test isa(x,Vector{ZZMPolyRingElem})
-@test isa(y,Vector{ZZMPolyRingElem})
-@test x==R.x_vars
-@test y==R.y_vars
-@test nvars(R.ring)==7
-
-R,x,y=xy_ring(4)
-
-@test isa(x,Vector{ZZMPolyRingElem})
-@test nvars(R.ring)==4
-@test length(R.y_vars)==0
+# deprecated DoublePolyRing / xy_ring still functions for one version
+R2 = xy_ring(4,3)[1]
+@test isa(R2, DoublePolyRing)
+@test nvars(R2.ring)==7
+@test length(R2.x_vars)==4
+@test length(R2.y_vars)==3
 
 end

--- a/test/mult_schub.jl
+++ b/test/mult_schub.jl
@@ -19,11 +19,11 @@ u = [2,4,3,1]
 v = [4,1,2,3]
 w = [4,2,3,1]
 
-@test lrc( u,v,w,4,R ) == (y[1]-y[4])*(y[3]-y[4])
+@test lrc( u,v,w,4,R; double=true ) == (y[1]-y[4])*(y[3]-y[4])
 
 
-f = evaluate( schub_poly([2,3,1],R), [y[1],y[2],y[3]],[-x[3],-x[2],-x[1]] )
-ss = expand_schub(f,3,R)
+f = evaluate( schub_poly([2,3,1],R; double=true), [y[1],y[2],y[3]],[-x[3],-x[2],-x[1]] )
+ss = expand_schub(f,3,R; double=true)
 
 @test ss.schubs == [ [1], [1,3,2], [2,3,1] ]
 @test ss.coeffs == [ y[1]*y[2] - y[1]*y[3] - y[2]*y[3] + y[3]^2, -2*y[1] + y[2] + y[3], 3 ]

--- a/test/mult_schub.jl
+++ b/test/mult_schub.jl
@@ -13,17 +13,19 @@ ss2 = mult_2schub([2,1], [1,3,2])
 @test ss==ss2
 
 
-R,x,y=xy_ring(5,5)
+R = schub_ring(5,5)
+x = extract_vars(R; varname=:x)
+y = extract_vars(R; varname=:y)
 
 u = [2,4,3,1]
 v = [4,1,2,3]
 w = [4,2,3,1]
 
-@test lrc( u,v,w,4,R; double=true ) == (y[1]-y[4])*(y[3]-y[4])
+@test lrc( u,v,w,4; ring=R, double=true ) == (y[1]-y[4])*(y[3]-y[4])
 
 
-f = evaluate( schub_poly([2,3,1],R; double=true), [y[1],y[2],y[3]],[-x[3],-x[2],-x[1]] )
-ss = expand_schub(f,3,R; double=true)
+f = evaluate( schub_poly([2,3,1]; ring=R, double=true), [y[1],y[2],y[3]],[-x[3],-x[2],-x[1]] )
+ss = expand_schub(f,3; ring=R, double=true)
 
 @test ss.schubs == [ [1], [1,3,2], [2,3,1] ]
 @test ss.coeffs == [ y[1]*y[2] - y[1]*y[3] - y[2]*y[3] + y[3]^2, -2*y[1] + y[2] + y[3], 3 ]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,8 @@ if isempty(ARGS)
         "permtools.jl", 
         "double_poly_ring.jl", 
         "ssyt.jl",
-       # "bpds.jl", 
-        "drifts.jl",
+       # "bpds.jl",
+       # drift methods moved to DriftPolynomials.jl
         "schub_polys.jl",
         "schubert_sum.jl",
         "mult_schub.jl"

--- a/test/schub_polys.jl
+++ b/test/schub_polys.jl
@@ -31,4 +31,32 @@ w=[1,4,3,2,10,9,8,7,6,5];
 w=[1,3,2,8,7,6,5,4];
 @test ngroth(w)==1711251
 
+
+# --- `double` keyword (Step A) ---
+
+w = [2,1,4,3]
+Rxy = xy_ring(3,3)[1]   # ring carrying y-variables
+
+# double=false: single polynomial, even though the ring has y-variables (new capability)
+p_single = schub_poly(w, Rxy; double=false)
+@test p_single == schub_poly(w, Rxy; double=false, method="bpd")
+@test p_single == schub_poly(w, Rxy; double=false, method="transition")
+@test p_single == schub_poly(w, Rxy; double=false, method="dd")
+# the y-variables of the ring are genuinely unused
+@test all( v -> !startswith(string(v), "y"), vars(p_single) )
+
+# double=true: factorial polynomial in x and y, methods agree
+p_double = schub_poly(w, Rxy; double=true)
+@test p_double == schub_poly(w, Rxy; double=true, method="bpd")
+@test p_double == schub_poly(w, Rxy; double=true, method="transition")
+@test p_double != p_single
+@test any( v -> startswith(string(v), "y"), vars(p_double) )
+
+# double=true on a y-free ring is an error
+@test_throws ArgumentError schub_poly(w, xy_ring(3,0)[1]; double=true)
+@test_throws ArgumentError groth_poly(w, xy_ring(3,0)[1]; double=true)
+
+# no ring supplied: double=true builds a ring with y-variables on its own
+@test any( v -> startswith(string(v), "y"), vars( schub_poly(w; double=true) ) )
+
 end

--- a/test/schub_polys.jl
+++ b/test/schub_polys.jl
@@ -2,25 +2,26 @@
 
 
 w=[2,1,4,3]
-R,x,y=xy_ring(3)
-p = schub_poly(w,R)
-q = groth_poly(w,R)
+R = schub_ring(3)
+x = extract_vars(R; varname=:x)
+p = schub_poly(w; ring=R)
+q = groth_poly(w; ring=R)
 
 @test p == x[1]*(x[1]+x[2]+x[3])
 @test q == x[1]*(x[1]+x[2]+x[3]-x[1]*x[2]-x[1]*x[3]-x[2]*x[3]+x[1]*x[2]*x[3])
 
 w = [1,4,2,3,7,6,5]
-R=xy_ring(6,6)[1]
-p1=schub_poly(w,R,method="bpd");
-p2=schub_poly(w,R,method="drift");   # :drift is deprecated and now aliased to :bpd
-p3=schub_poly(w,R,method="transition");
+R = schub_ring(6,6)
+p1=schub_poly(w; ring=R, method="bpd");
+p2=schub_poly(w; ring=R, method="drift");   # :drift is deprecated and now aliased to :bpd
+p3=schub_poly(w; ring=R, method="transition");
 
 @test p1==p2
 @test p2==p3
 
-R=xy_ring(6)[1]
-p1=schub_poly(w,R,method="bpd");
-p2=schub_poly(w,R,method="dd");
+R = schub_ring(6)
+p1=schub_poly(w; ring=R, method="bpd");
+p2=schub_poly(w; ring=R, method="dd");
 
 @test p1==p2
 
@@ -32,47 +33,47 @@ w=[1,3,2,8,7,6,5,4];
 @test ngroth(w)==1711251
 
 
-# --- `double` keyword (Step A) ---
+# --- `double` keyword ---
 
 w = [2,1,4,3]
-Rxy = xy_ring(3,3)[1]   # ring carrying y-variables
+Rxy = schub_ring(3,3)   # ring carrying y-variables
 
 # double=false: single polynomial, even though the ring has y-variables (new capability)
-p_single = schub_poly(w, Rxy; double=false)
-@test p_single == schub_poly(w, Rxy; double=false, method="bpd")
-@test p_single == schub_poly(w, Rxy; double=false, method="transition")
-@test p_single == schub_poly(w, Rxy; double=false, method="dd")
+p_single = schub_poly(w; ring=Rxy, double=false)
+@test p_single == schub_poly(w; ring=Rxy, double=false, method="bpd")
+@test p_single == schub_poly(w; ring=Rxy, double=false, method="transition")
+@test p_single == schub_poly(w; ring=Rxy, double=false, method="dd")
 # the y-variables of the ring are genuinely unused
 @test all( v -> !startswith(string(v), "y"), vars(p_single) )
 
 # double=true: factorial polynomial in x and y, methods agree
-p_double = schub_poly(w, Rxy; double=true)
-@test p_double == schub_poly(w, Rxy; double=true, method="bpd")
-@test p_double == schub_poly(w, Rxy; double=true, method="transition")
+p_double = schub_poly(w; ring=Rxy, double=true)
+@test p_double == schub_poly(w; ring=Rxy, double=true, method="bpd")
+@test p_double == schub_poly(w; ring=Rxy, double=true, method="transition")
 @test p_double != p_single
 @test any( v -> startswith(string(v), "y"), vars(p_double) )
 
 # double=true on a y-free ring is an error
-@test_throws ArgumentError schub_poly(w, xy_ring(3,0)[1]; double=true)
-@test_throws ArgumentError groth_poly(w, xy_ring(3,0)[1]; double=true)
+@test_throws ArgumentError schub_poly(w; ring=schub_ring(3,0), double=true)
+@test_throws ArgumentError groth_poly(w; ring=schub_ring(3,0), double=true)
 
 # no ring supplied: double=true builds a ring with y-variables on its own
 @test any( v -> startswith(string(v), "y"), vars( schub_poly(w; double=true) ) )
 
 
-# --- dominant permutations: transition base case is drift-free (Step C2) ---
+# --- dominant permutations: transition base case is drift-free ---
 # For a dominant w, max_transition(w) is empty, so :transition falls back to the
 # single flat (Rothe) BPD; this must agree with :bpd in both single and double.
 
 for wd in ( [3,2,1], [1,3,4,2] )
-  Rd = xy_ring(4,4)[1]
-  @test schub_poly(wd, Rd; double=false, method="transition") ==
-        schub_poly(wd, Rd; double=false, method="bpd")
-  @test schub_poly(wd, Rd; double=true,  method="transition") ==
-        schub_poly(wd, Rd; double=true,  method="bpd")
+  Rd = schub_ring(4,4)
+  @test schub_poly(wd; ring=Rd, double=false, method="transition") ==
+        schub_poly(wd; ring=Rd, double=false, method="bpd")
+  @test schub_poly(wd; ring=Rd, double=true,  method="transition") ==
+        schub_poly(wd; ring=Rd, double=true,  method="bpd")
   # memoized transition path hits the same fallback
-  @test schub_poly(wd, Rd; double=true, memo=true) ==
-        schub_poly(wd, Rd; double=true, method="bpd")
+  @test schub_poly(wd; ring=Rd, double=true, memo=true) ==
+        schub_poly(wd; ring=Rd, double=true, method="bpd")
 end
 
 end

--- a/test/schub_polys.jl
+++ b/test/schub_polys.jl
@@ -12,7 +12,7 @@ q = groth_poly(w,R)
 w = [1,4,2,3,7,6,5]
 R=xy_ring(6,6)[1]
 p1=schub_poly(w,R,method="bpd");
-p2=schub_poly(w,R,method="drift");
+p2=schub_poly(w,R,method="drift");   # :drift is deprecated and now aliased to :bpd
 p3=schub_poly(w,R,method="transition");
 
 @test p1==p2
@@ -58,5 +58,21 @@ p_double = schub_poly(w, Rxy; double=true)
 
 # no ring supplied: double=true builds a ring with y-variables on its own
 @test any( v -> startswith(string(v), "y"), vars( schub_poly(w; double=true) ) )
+
+
+# --- dominant permutations: transition base case is drift-free (Step C2) ---
+# For a dominant w, max_transition(w) is empty, so :transition falls back to the
+# single flat (Rothe) BPD; this must agree with :bpd in both single and double.
+
+for wd in ( [3,2,1], [1,3,4,2] )
+  Rd = xy_ring(4,4)[1]
+  @test schub_poly(wd, Rd; double=false, method="transition") ==
+        schub_poly(wd, Rd; double=false, method="bpd")
+  @test schub_poly(wd, Rd; double=true,  method="transition") ==
+        schub_poly(wd, Rd; double=true,  method="bpd")
+  # memoized transition path hits the same fallback
+  @test schub_poly(wd, Rd; double=true, memo=true) ==
+        schub_poly(wd, Rd; double=true, method="bpd")
+end
 
 end

--- a/test/ssyt.jl
+++ b/test/ssyt.jl
@@ -24,6 +24,9 @@ p = schur_poly(la,ff,R)
 
 @test p == x[1]^2*x[2] + x[1]^2*y[1] + x[1]*x[2]^2 + 2*x[1]*x[2]*y[1] + x[1]*x[2]*y[2] + x[1]*y[1]^2 + x[1]*y[1]*y[2] + x[2]^2*y[1] + x[2]*y[1]^2 + x[2]*y[1]*y[2] + y[1]^2*y[2]
 
+# `double` keyword: single Schur polynomial in a ring that carries y-variables
+@test schur_poly(la,ff,R; double=false) == x[1]^2*x[2] + x[1]*x[2]^2
+
 la = [3,2,1]
 ff = [2,4,5]
 R = xy_ring(5)[1]

--- a/test/ssyt.jl
+++ b/test/ssyt.jl
@@ -1,44 +1,48 @@
 @testset "SSYT" begin
 
 
-R,x,y=xy_ring(5)
+R = schub_ring(5)
+x = extract_vars(R; varname=:x)
 
 la=[2,1]
 ff=2
-p = schur_poly(la,ff,R)
+p = schur_poly(la,ff; ring=R)
 
 @test p==x[1]^2*x[2]+x[1]*x[2]^2
 
-p2 = schur_poly(la,ff,R; mu=[1])
+p2 = schur_poly(la,ff; ring=R, mu=[1])
 
 @test p2==x[1]^2+2*x[1]*x[2]+x[2]^2
 
-p3 = schur_poly(la,ff,R; mu=[1],rowmin=true)
+p3 = schur_poly(la,ff; ring=R, mu=[1], rowmin=true)
 
 @test p3==x[1]*x[2]+x[2]^2
 
-R,x,y=xy_ring(2,2)
+R = schub_ring(2,2)
+x = extract_vars(R; varname=:x)
+y = extract_vars(R; varname=:y)
 la=[2,1]
 ff=2
-p = schur_poly(la,ff,R)
 
+# single vs double is controlled by the `double` keyword (not the ring's shape)
+@test schur_poly(la,ff; ring=R, double=false) == x[1]^2*x[2] + x[1]*x[2]^2
+@test schur_poly(la,ff; ring=R) == x[1]^2*x[2] + x[1]*x[2]^2   # default is single
+
+p = schur_poly(la,ff; ring=R, double=true)   # double/factorial Schur polynomial
 @test p == x[1]^2*x[2] + x[1]^2*y[1] + x[1]*x[2]^2 + 2*x[1]*x[2]*y[1] + x[1]*x[2]*y[2] + x[1]*y[1]^2 + x[1]*y[1]*y[2] + x[2]^2*y[1] + x[2]*y[1]^2 + x[2]*y[1]*y[2] + y[1]^2*y[2]
-
-# `double` keyword: single Schur polynomial in a ring that carries y-variables
-@test schur_poly(la,ff,R; double=false) == x[1]^2*x[2] + x[1]*x[2]^2
 
 la = [3,2,1]
 ff = [2,4,5]
-R = xy_ring(5)[1]
-p = schur_poly(la,ff,R)
+R = schub_ring(5)
+p = schur_poly(la,ff; ring=R)
 
 @test length( ssyt(la,ff) ) == 44
 @test sum(coefficients(p))==44
 
 la = [4,4,2,1]
 ff = [[3,4,4,5],[3,4,5,6],[4,5],[6]]
-R = xy_ring(6)[1]
-p = schur_poly(la,ff,R);
+R = schub_ring(6)
+p = schur_poly(la,ff; ring=R);
 tt = ssyt(la,ff);
 
 @test sum(coefficients(p))==3693


### PR DESCRIPTION
Major overhaul: the double/single versions of Schubert polynomials are now controlled by the keyword `double` (default false). The shape of the ambient ring only constrains the variables involved (it is big enough by default).